### PR TITLE
Eliminate nested

### DIFF
--- a/cxx/include/mspass/utility/ErrorLogger.h
+++ b/cxx/include/mspass/utility/ErrorLogger.h
@@ -22,7 +22,7 @@ public:
   \param alg is assigned to algorithm attribute.
   \param merr is parsed to fill the message and severity fields.
   Note p_id is always fetched with the system call getpid in the constructor.*/
-  LogData(int jid, std::string alg, mspass::MsPASSError& merr);
+  LogData(const int jid, const std::string alg,const mspass::MsPASSError& merr);
   friend ostream& operator<<(ostream&, LogData&);
 };
 /*! \brief Container to hold error logs for a data object.
@@ -51,7 +51,27 @@ public:
 
   \return size of error log after insertion.
   */
-  int log_error(mspass::MsPASSError& merr);
+  int log_error(const mspass::MsPASSError& merr);
+  /*! Log one a message directly with a specified severity.
+
+    This is a convenience overload of log_error.  It splits the
+    MsPASSError components as arguments with a default that
+    allows a default behavior of Invalid as the error state.
+
+    \param mess is the message to be posted.
+    \param level is the badness level to be set with the message.
+       (default is ErrorSeverity::Invalid).
+
+    \return size of error log after insertion.
+    */
+  int log_error(const std::string mess,
+		  const mspass::ErrorSeverity level=ErrorSeverity::Invalid)
+  {
+    MsPASSError err(mess,level);
+    int count=this->log_error(err);
+    return count;
+  };
+
   /*! \brief Log a verbose message marking it informational.
 
   Frequently programs need a verbose option to log something of interest
@@ -59,7 +79,7 @@ public:
   method posts the string mess and marks it Informational. Returns
   the size of the log after insertion.
   */
-  int log_verbose(std::string mess);
+  int log_verbose(const std::string mess);
   std::list<LogData> get_error_log(){return allmessages;};
   int size(){return allmessages.size();};
   ErrorLogger& operator=(const ErrorLogger& parent);

--- a/cxx/include/mspass/utility/MsPASSCoreTS.h
+++ b/cxx/include/mspass/utility/MsPASSCoreTS.h
@@ -13,24 +13,26 @@ means the actual contents of this object are minimal.  For the initial implement
 hook is the string that is used in MongoDB as an external form fo the ObjectID.   This assumption
 is the get and put methods for the objectid string will be sufficient for a python wrapper to 
 associate data with the a unique document in the database.   
+
+A key feature this component contains is hooks to the ErrorLogger functionality of mspass.
+That is, all data objects in mspass should not abort on most errors, but post messages to
+the error log.   When objects are saved writers should normally drop data with errors posted
+at some defined level (usually ErrorSeverity::Invalid).  Note the original design had the
+error logging component as a nested/inner class of MsPASSCoreTS.   We found it was problematic
+to handle tested classes with python wrappers so MsPASSCoreTS was made a child of ErrorLogger.
+This strongly violates the normal rules for how the API should define this because 
+ErrorLogger is a type example of a "has a" instead of an "is a".  
 */
-class MsPASSCoreTS
+class MsPASSCoreTS : public ErrorLogger
 {
   public:
-    /*! \brief  Error logging component.
-
-    Data processing always involves grey areas of errors.   Some errors invalidate the data and
-    others make it just questionable.   Some errors should be fatal, but we may not want to
-    abort everything in a large job running for many hours.   This object in MsPASS implements
-    a generic, scalable log mechanism where objects can post errors to the log and abort only
-    when essential.   The idea is that log messages are cached with the data and saved only
-    when we ask the data in a container to be saved.   Intermediate processing results can also
-    be tested for validity through the ErrorLogger API.  */
-    ErrorLogger elog;
     /*! Default constructor.   Does almost nothing. */
-    MsPASSCoreTS() : elog(){hex_id="INVALID";};
+    MsPASSCoreTS() : ErrorLogger(){hex_id="INVALID";};
     /*! Standard copy constructor. */
-    MsPASSCoreTS(const MsPASSCoreTS& parent){hex_id=parent.hex_id;};
+    MsPASSCoreTS(const MsPASSCoreTS& parent) : ErrorLogger(dynamic_cast<const ErrorLogger&>(parent))
+    {
+	hex_id=parent.hex_id;
+    };
     /*! Standard assignment operator. */
     MsPASSCoreTS& operator=(const MsPASSCoreTS& parent)
     {

--- a/cxx/include/mspass/utility/MsPASSCoreTS.h
+++ b/cxx/include/mspass/utility/MsPASSCoreTS.h
@@ -13,26 +13,24 @@ means the actual contents of this object are minimal.  For the initial implement
 hook is the string that is used in MongoDB as an external form fo the ObjectID.   This assumption
 is the get and put methods for the objectid string will be sufficient for a python wrapper to 
 associate data with the a unique document in the database.   
-
-A key feature this component contains is hooks to the ErrorLogger functionality of mspass.
-That is, all data objects in mspass should not abort on most errors, but post messages to
-the error log.   When objects are saved writers should normally drop data with errors posted
-at some defined level (usually ErrorSeverity::Invalid).  Note the original design had the
-error logging component as a nested/inner class of MsPASSCoreTS.   We found it was problematic
-to handle tested classes with python wrappers so MsPASSCoreTS was made a child of ErrorLogger.
-This strongly violates the normal rules for how the API should define this because 
-ErrorLogger is a type example of a "has a" instead of an "is a".  
 */
-class MsPASSCoreTS : public ErrorLogger
+class MsPASSCoreTS
 {
   public:
+    /*! \brief  Error logging component.
+
+    Data processing always involves grey areas of errors.   Some errors invalidate the data and
+    others make it just questionable.   Some errors should be fatal, but we may not want to
+    abort everything in a large job running for many hours.   This object in MsPASS implements
+    a generic, scalable log mechanism where objects can post errors to the log and abort only
+    when essential.   The idea is that log messages are cached with the data and saved only
+    when we ask the data in a container to be saved.   Intermediate processing results can also
+    be tested for validity through the ErrorLogger API.  */
+    ErrorLogger elog;
     /*! Default constructor.   Does almost nothing. */
-    MsPASSCoreTS() : ErrorLogger(){hex_id="INVALID";};
+    MsPASSCoreTS() : elog(){hex_id="INVALID";};
     /*! Standard copy constructor. */
-    MsPASSCoreTS(const MsPASSCoreTS& parent) : ErrorLogger(dynamic_cast<const ErrorLogger&>(parent))
-    {
-	hex_id=parent.hex_id;
-    };
+    MsPASSCoreTS(const MsPASSCoreTS& parent){hex_id=parent.hex_id;};
     /*! Standard assignment operator. */
     MsPASSCoreTS& operator=(const MsPASSCoreTS& parent)
     {

--- a/cxx/python/mspass_wrapper.cpp
+++ b/cxx/python/mspass_wrapper.cpp
@@ -473,12 +473,12 @@ PYBIND11_MODULE(mspasspy,m)
     .def("size",&mspass::ErrorLogger::size)
     .def("worst_errors",&mspass::ErrorLogger::worst_errors)
   ;
-  py::class_<mspass::MsPASSCoreTS,mspass::ErrorLogger>(m,
+  py::class_<mspass::MsPASSCoreTS>(m,
                "MsPASSCoreTS","class to extend a data object to integrate with MongoDB")
     .def(py::init<>())
     .def("set_id",&mspass::MsPASSCoreTS::set_id,"Set the mongodb unique id to associate with this object")
     .def("get_id",&mspass::MsPASSCoreTS::get_id,"Return the mongodb uniqueid associated with a data object")
-    ;
+    .def_readwrite("elog",&mspass::MsPASSCoreTS::elog,"Error logger object");
   /* These two APIs are incomplete but are nontheless mostly wrappers for
   Core versions of same */
   py::class_<mspass::TimeSeries,mspass::CoreTimeSeries,mspass::MsPASSCoreTS>

--- a/cxx/python/mspass_wrapper.cpp
+++ b/cxx/python/mspass_wrapper.cpp
@@ -78,6 +78,7 @@ using mspass::ErrorLogger;
 using mspass::pfread;
 using mspass::MDDefFormat;
 using mspass::MetadataDefinitions;
+using mspass::MsPASSCoreTS;
 /* We enable this gem for reasons explain in the documentation for pybinde11
 at this url:  https://pybind11.readthedocs.io/en/master/advanced/cast/stl.html
 Upshot is we need the py::bind line at the start of the module definition.
@@ -221,11 +222,6 @@ public:
     );
   }
 };
-/* Documentation says this is needed for c11 compilation, but cannot make
-it work. Preserve for now.
-template <typename... Args>
-using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
-*/
 PYBIND11_MODULE(mspasspy,m)
 {
   py::bind_vector<std::vector<double>>(m, "Vector");
@@ -470,13 +466,15 @@ PYBIND11_MODULE(mspasspy,m)
     .def("set_algorithm",&mspass::ErrorLogger::set_algorithm)
     .def("get_job_id",&mspass::ErrorLogger::get_job_id)
     .def("get_algorithm",&mspass::ErrorLogger::get_algorithm)
-    .def("log_error",&mspass::ErrorLogger::log_error)
+    .def("log_error",py::overload_cast<const MsPASSError&>(&mspass::ErrorLogger::log_error),"log error thrown as MsPASSError")
+    .def("log_error",py::overload_cast<const std::string,const ErrorSeverity>(&mspass::ErrorLogger::log_error),"log a message at a specified severity level")
     .def("log_verbose",&mspass::ErrorLogger::log_verbose)
     .def("get_error_log",&mspass::ErrorLogger::get_error_log)
     .def("size",&mspass::ErrorLogger::size)
     .def("worst_errors",&mspass::ErrorLogger::worst_errors)
   ;
-  py::class_<mspass::MsPASSCoreTS>(m,"MsPASSCoreTS","class to extend a data object to integrate with MongoDB")
+  py::class_<mspass::MsPASSCoreTS,mspass::ErrorLogger>(m,
+               "MsPASSCoreTS","class to extend a data object to integrate with MongoDB")
     .def(py::init<>())
     .def("set_id",&mspass::MsPASSCoreTS::set_id,"Set the mongodb unique id to associate with this object")
     .def("get_id",&mspass::MsPASSCoreTS::get_id,"Return the mongodb uniqueid associated with a data object")

--- a/cxx/src/lib/utility/ErrorLogger.cc
+++ b/cxx/src/lib/utility/ErrorLogger.cc
@@ -3,7 +3,8 @@ using namespace mspass;
 namespace mspass
 {
 /* First code for the LogData class that are too long for inline */
-LogData::LogData(int jid, std::string alg, mspass::MsPASSError& merr)
+LogData::LogData(const int jid, const std::string alg,
+  const mspass::MsPASSError& merr)
 {
   job_id=jid;
   p_id=getpid();
@@ -58,13 +59,13 @@ ErrorLogger& ErrorLogger::operator=(const ErrorLogger& parent)
   }
   return *this;
 }
-int ErrorLogger::log_error(mspass::MsPASSError& merr)
+int ErrorLogger::log_error(const mspass::MsPASSError& merr)
 {
   LogData thislog(this->job_id,this->algorithm,merr);
   allmessages.push_back(thislog);
   return allmessages.size();
 }
-int ErrorLogger::log_verbose(std::string mess)
+int ErrorLogger::log_verbose(const std::string mess)
 {
   LogData entry;
   entry.job_id=this->job_id;

--- a/python/obspy2mspass.py
+++ b/python/obspy2mspass.py
@@ -1,0 +1,200 @@
+# Converter from obspy Trace object to mspass::TimeSeries
+from mspasspy import CoreTimeSeries
+from mspasspy import TimeSeries
+from mspasspy import TimeReferenceType
+from mspasspy import MetadataDefinitions
+from mspasspy import MDDefFormat
+from mspasspy import MDtype
+# We need this for error ErrorLogger
+from mspasspy import MsPASSError
+from mspasspy import ErrorSeverity
+
+from obspy import Trace
+def obspy2mspass(d,mdef,mdother,aliases):
+    """
+    Convert an obspy Trace object to a TimeSeries object.
+
+    Arguments:
+    d - obspy trace object to convert
+    mdef - global metadata catalog.   Used to guarantee all names used are registered.
+    mdother - This function always loads obspy required attributes and passes the directly to the mspass
+        TimeSeries object..  For each entry in mdother the procedure tries to fetch that attribute.  It's type
+        is then extracted from the MetadataDefinitions object and saved with the same key.
+    aliases - is a list of attributes that should be posted to output with an alias name.  Aliases have
+        a large overhead as the algorithm first looks for the unique key associated with the aliases and
+        deletes it from the output before adding it back with the alias.   This is an essential feature to
+        prevent duplicates that could easily get out of sync.  Aliases should generally be avoided but
+        can be a useful feature.
+    Returns a mspass TimeSeries object equivalent to obspy input but reorganized into mspass class structure
+"""
+# First get the data size to know use allocating constructor for TimeSeries
+    ns=d.stats.npts
+    dout=CoreTimeSeries(ns)
+    # an api change is needed here.  Also TimeSeries needs to handle invalid objectid
+    dout=TimeSeries(dout,"INVALID")
+    dout.ns=ns
+# Now extract TimeSeries attributes equivalent in d.stats and write to output
+    dout.dt=d.stats.delta
+# obspy only understands UTC time as a standard so we just set it
+    dout.tref=TimeReferenceType.UTC
+# This is a collision point between C and python.  In python a bool is a class
+# so cannot just use a python syntax here. C treats bool as an int and anything
+# not 0 is considered true
+    dout.live=1
+    t0utc=d.stats.starttime
+    dout.t0=t0utc.timestamp
+# These are required obspy attributes we pass to mspass::Metadata
+    sta=d.stats.station
+    net=d.stats.network
+    chan=d.stats.channel
+    calib=d.stats.calib
+    dout.put("station",sta)
+    dout.put("network",net)
+    dout.put("channel",chan)
+    dout.put("calib",calib)
+# C++ library uses an stl vector container to contain the seismic samples
+# pybind11 includes a wrapper for append which is equivalent to the C++ method
+# push_back.   Hence, this loop is a copy of samples to the C++ container.
+    for i in range(ns):
+        dout.s.append(d.data[i])
+# Things below here can throw exceptions.  We capture them with a feature
+# of mspass using the ErrorLogger object that is a component of the TimeSeries
+# object. Here we initialize the error logger to post obspy2mspass as the algorithm
+    dout.set_algorithm("obspy2mspass")
+
+# Mow load and copy all mdother data. Cannot assume the set of attributes
+# requested are actually with the data being imported for cxx
+    for key in mdother:
+        try:
+            val=d.stats[key]
+            try:
+                typ = mdef.type(key)
+                if(typ==MDtype.Int64 or typ==MDtype.Long or typ==MDtype.Integer) :
+                    # assumes python casting does nothing if val already of that type
+                    # this will fail if we try to convert strings to numbers so
+                    # we use an error handler here
+                    try :
+                        val_to_save=int(val)
+                        dout.put(key,val_to_save)
+                    except ValueError:
+                        error_message="obspy2mspass: Error handling attribute with key="+key+"\n"
+                        error_message=error_message+"Data in trace attribute with this key cannot be converted to an Int64 as required by schema\n"
+                        error_message=error_message+"Content stored with this key=" + str(val)
+                        dout.log_error(error_messag3e,ErrorSeverity.Complaint)
+                        # testing - delete for release
+                        print("Saved message=",error_message," to log")
+                        #print("obspy2mspass: Error handling attribute with key="+key)
+                        #print("Data in trace attribute with this key cannot be converted to an Int64 as required by schema")
+                        #print("Content stored with this key=",val)
+                elif(typ==MDtype.Real or typ==MDtype.Double or typ==MDtype.Real64) :
+                    # identical to above but for floats = double in python
+                    try :
+                        val_to_save=float(val)
+                        dout.put(key,val_to_save)
+                    except ValueError:
+                        error_message="obspy2mspass: Error handling attribute with key="+key+"\n"
+                        error_message=error_message + "Data in trace attribute with this key cannot be converted to Real64 as required by schema\n"
+                        error_message=error_message + "Content stored this key="+str(val)+"\n"
+                        dout.log_error(error_message,ErrorSeverity.Complaint)
+                # Section for short versions of numeric types.   For now we promote
+                # all int32 to int64 and real32 (C float) to real64(C double)
+                # This code repeats above intentionally in case these cases
+                # require later tweeks
+                # Note for present we don't worry about unsigned int but that
+                # might be useful
+                elif(typ==MDtype.Int32) :
+                    try:
+                        val_to_save=int(val)
+                        dout.put(key,val_to_save)
+                        if(val>2147483648 or val<-2147483648) :
+                            mess="obspy2mspass:  Attribute with key="+key+"\n"
+                            mess=mess + "Valued stored="+str(val)+" will overflow Int32 required by schema\n"
+                            mess=mess + "Converted for now to Int64, but may be wrong in output if saved\n"
+                            dout.log_error(mess,ErrorSeverity.Complaint)
+                    except ValueError:
+                        mess="obspy2mspass: Error handling attribute with key="+key+"\n"
+                        mess=mess + "Data in trace attribute with this key cannot be converted to an integer as required by schema\n"
+                        mess=mess + "Content stored with this key="+str(val)+"\n"
+                        dout.log_error(mess,ErrorSeverity.Complaint)
+                elif(typ==MDtype.Real32):
+                    try :
+                        val_to_save=float(val)
+                        dout.put(key,val_to_save)
+                    except ValueError:
+                        mess="obspy2mspass: Error handling attribute with key="+key+"\n"
+                        mess=mess + "Data in trace attribute with this key cannot be converted to Real64 as required by schema\n"
+                        mess=mess + "Note it is defines as a Real32, but is always promoted to Real64 inside mspass\n"
+                        mess=mess + "Content stored this key="+str(val)+"\n"
+                        dout.log_error(mess,ErrorSeverity.Complaint)
+                elif(typ==MDtype.String) :
+                    # As far as I can tell the python str function is bombproof
+                    # and will always return a result for any numeric typeself
+                    # including np numeric types.   Hence, there is no try
+                    # block for conversion errors there
+                    val_to_save=str(val)
+                    dout.put(key,val_to_save)
+                elif(typ==MDtype.Boolean) :
+                    # bool function also seems bombproof and a bool of a logical
+                    # (e.g. bool(True)) does nothing.  Hence, we also don't need
+                    # an error handler here
+                    val_to_save=bool(val)
+                    dout.put(key,val_to_save)
+                else :
+                    mess="obspy2mspass:  Cannot handle attribute with key =" + "\n"
+                    + "MetadataDefinitions has an error and contains an unsupported type definition\n"
+                    mess=mess + "Check data used to generate MetadataDefinitions for errors"
+                    dout.log_error(mess,ErrorSeverity.Complaint)
+            except RuntimeError:
+                mess="obspy2mspass:  optional key="+key+" is undefined in master schema\n"
+                + "attribute linked to that key will not be copied to mspass TimeSeries\n"
+                dout.log_error(mess,ErrorSeverity.Complaint)
+        except KeyError:
+            mess="obspy2mspass:  optional key="+key+" not found in obspy stats\n"
+            mess=mess + "attribute linked to that key will not be copied to mspass TimeSeries\n"
+            dout.log_error(mess,ErrorSeverity.Complaint)
+    # Now handle entries that are to be set as aliases.  As docstring says the approach
+    # is to delete contents of a master name associated with the requested alias to
+    # avoid stale duplicates.  An additional complication is that we also have to clear
+    # the entry that says the original attribute was saved.   The clear method does that
+    for a in aliases:
+        # The C function returns an std::pair.  pybind11 wrappers convert this to
+        # a 2 element tuple with 0 as the unique key name and the 1 having the type
+        # Error handler is necessary in case the alias is not undefined
+        try:
+            p=mdef.unique_name(a)
+            ukey=p[0]
+            typ=p[1]
+            if(dout.is_defined(ukey)) :
+                # these work because 32s were cast to 64s above we don't worry if that happens
+                if(typ==MDtype.Int64 or typ==MDtype.Long or typ==MDtype.Integer \
+                                or typ==MDtype.Int32):
+                    val=dout.get_int(ukey)
+                    dout.put(a,val)
+                    dout.clear(ukey)
+                elif(typ==MDtype.Real or typ==MDtype.Double or typ==MDtype.Real64 \
+                            or typ==MDtype.Real32) :
+                    val=dout.get_double(ukey)
+                    dout.put(a,val)
+                    dout.clear(ukey)
+                elif(typ==MDtype.String) :
+                    val=dout.get_string(ukey)
+                    dout.put(a,val)
+                    dout.clear(ukey)
+                elif(typ==MDtype.Boolean) :
+                    val=dout.get_bool(ukey)
+                    dout.put(a,val)
+                    dout.clear(ukey)
+                else :
+                    # This block should never be executed, but good for stability
+                    mess="obspy2mspass (WARNING): cannot set attribute alias="+a+"\n"
+                    mess=mess + "unique key="+ukey+" has illegal type\n"
+                    mess=mess + "Check aliases section data used to create MetadataDefinitions for errors"
+                    dout.log_error(mess,ErrorSeverity.Complaint)
+            else :
+                mess="obspy2mspass (WARNING):  cannot rename attribute with key="+ukey+"\n"
+                mess=mess + "Requested change to alias name="+a+" failed because "+ukey+" was not previously set\n"
+                dout.log_error(mess,ErrorSeverity.Complaint)
+        except RuntimeError:
+            mess="obspy2mspass:  Error during processing aliases list for alias key="+a+"\n"
+            dout.log_error(mess,ErrorSeverity.Complaint)
+    return dout

--- a/python/obspy2mspass.py
+++ b/python/obspy2mspass.py
@@ -60,7 +60,7 @@ def obspy2mspass(d,mdef,mdother,aliases):
 # Things below here can throw exceptions.  We capture them with a feature
 # of mspass using the ErrorLogger object that is a component of the TimeSeries
 # object. Here we initialize the error logger to post obspy2mspass as the algorithm
-    dout.set_algorithm("obspy2mspass")
+    dout.elog.set_algorithm("obspy2mspass")
 
 # Mow load and copy all mdother data. Cannot assume the set of attributes
 # requested are actually with the data being imported for cxx
@@ -80,7 +80,7 @@ def obspy2mspass(d,mdef,mdother,aliases):
                         error_message="obspy2mspass: Error handling attribute with key="+key+"\n"
                         error_message=error_message+"Data in trace attribute with this key cannot be converted to an Int64 as required by schema\n"
                         error_message=error_message+"Content stored with this key=" + str(val)
-                        dout.log_error(error_messag3e,ErrorSeverity.Complaint)
+                        dout.elog.log_error(error_messag3e,ErrorSeverity.Complaint)
                         # testing - delete for release
                         print("Saved message=",error_message," to log")
                         #print("obspy2mspass: Error handling attribute with key="+key)
@@ -95,7 +95,7 @@ def obspy2mspass(d,mdef,mdother,aliases):
                         error_message="obspy2mspass: Error handling attribute with key="+key+"\n"
                         error_message=error_message + "Data in trace attribute with this key cannot be converted to Real64 as required by schema\n"
                         error_message=error_message + "Content stored this key="+str(val)+"\n"
-                        dout.log_error(error_message,ErrorSeverity.Complaint)
+                        dout.elog.log_error(error_message,ErrorSeverity.Complaint)
                 # Section for short versions of numeric types.   For now we promote
                 # all int32 to int64 and real32 (C float) to real64(C double)
                 # This code repeats above intentionally in case these cases
@@ -110,12 +110,12 @@ def obspy2mspass(d,mdef,mdother,aliases):
                             mess="obspy2mspass:  Attribute with key="+key+"\n"
                             mess=mess + "Valued stored="+str(val)+" will overflow Int32 required by schema\n"
                             mess=mess + "Converted for now to Int64, but may be wrong in output if saved\n"
-                            dout.log_error(mess,ErrorSeverity.Complaint)
+                            dout.elog.log_error(mess,ErrorSeverity.Complaint)
                     except ValueError:
                         mess="obspy2mspass: Error handling attribute with key="+key+"\n"
                         mess=mess + "Data in trace attribute with this key cannot be converted to an integer as required by schema\n"
                         mess=mess + "Content stored with this key="+str(val)+"\n"
-                        dout.log_error(mess,ErrorSeverity.Complaint)
+                        dout.elog.log_error(mess,ErrorSeverity.Complaint)
                 elif(typ==MDtype.Real32):
                     try :
                         val_to_save=float(val)
@@ -125,7 +125,7 @@ def obspy2mspass(d,mdef,mdother,aliases):
                         mess=mess + "Data in trace attribute with this key cannot be converted to Real64 as required by schema\n"
                         mess=mess + "Note it is defines as a Real32, but is always promoted to Real64 inside mspass\n"
                         mess=mess + "Content stored this key="+str(val)+"\n"
-                        dout.log_error(mess,ErrorSeverity.Complaint)
+                        dout.elog.log_error(mess,ErrorSeverity.Complaint)
                 elif(typ==MDtype.String) :
                     # As far as I can tell the python str function is bombproof
                     # and will always return a result for any numeric typeself
@@ -143,15 +143,15 @@ def obspy2mspass(d,mdef,mdother,aliases):
                     mess="obspy2mspass:  Cannot handle attribute with key =" + "\n"
                     + "MetadataDefinitions has an error and contains an unsupported type definition\n"
                     mess=mess + "Check data used to generate MetadataDefinitions for errors"
-                    dout.log_error(mess,ErrorSeverity.Complaint)
+                    dout.elog.log_error(mess,ErrorSeverity.Complaint)
             except RuntimeError:
                 mess="obspy2mspass:  optional key="+key+" is undefined in master schema\n"
                 + "attribute linked to that key will not be copied to mspass TimeSeries\n"
-                dout.log_error(mess,ErrorSeverity.Complaint)
+                dout.elog.log_error(mess,ErrorSeverity.Complaint)
         except KeyError:
             mess="obspy2mspass:  optional key="+key+" not found in obspy stats\n"
             mess=mess + "attribute linked to that key will not be copied to mspass TimeSeries\n"
-            dout.log_error(mess,ErrorSeverity.Complaint)
+            dout.elog.log_error(mess,ErrorSeverity.Complaint)
     # Now handle entries that are to be set as aliases.  As docstring says the approach
     # is to delete contents of a master name associated with the requested alias to
     # avoid stale duplicates.  An additional complication is that we also have to clear
@@ -189,12 +189,12 @@ def obspy2mspass(d,mdef,mdother,aliases):
                     mess="obspy2mspass (WARNING): cannot set attribute alias="+a+"\n"
                     mess=mess + "unique key="+ukey+" has illegal type\n"
                     mess=mess + "Check aliases section data used to create MetadataDefinitions for errors"
-                    dout.log_error(mess,ErrorSeverity.Complaint)
+                    dout.elog.log_error(mess,ErrorSeverity.Complaint)
             else :
                 mess="obspy2mspass (WARNING):  cannot rename attribute with key="+ukey+"\n"
                 mess=mess + "Requested change to alias name="+a+" failed because "+ukey+" was not previously set\n"
-                dout.log_error(mess,ErrorSeverity.Complaint)
+                dout.elog.log_error(mess,ErrorSeverity.Complaint)
         except RuntimeError:
             mess="obspy2mspass:  Error during processing aliases list for alias key="+a+"\n"
-            dout.log_error(mess,ErrorSeverity.Complaint)
+            dout.elog.log_error(mess,ErrorSeverity.Complaint)
     return dout

--- a/python/tests/README
+++ b/python/tests/README
@@ -1,0 +1,7 @@
+This is a pair of python test scripts to validate wrappers and the 
+new obspy2mspass converter.   Data files required to run these scripts
+are also in this directory.   This set of files need to be moved elsewhere
+(probably to tests) but I don't know how to do that and mesh with the
+build system. Hence, I'm posting these now for Ian to sort out.  
+
+When this is resolved, use git rm to delete this file.

--- a/python/tests/obspy_namespace.pf
+++ b/python/tests/obspy_namespace.pf
@@ -1,0 +1,73 @@
+sampling_rate &Arr{
+concept &Tbl{
+Data sampling rate.  Normally in Hz=1/seconds
+}
+type double
+}
+delta &Arr{
+concept &Tbl{
+Sampling interval (in seconds)
+}
+type double
+}
+calib &Arr{
+concept &Tbl{
+Nominal conversion factor for changing sample data to ground motion units.
+Usually has units of (nm/s)/count for integer data.   When samples are floating
+point a scale factor to standard units of nm/s.
+}
+type double
+}
+npts &Arr{
+concept &Tbl{
+number of samples in waveform segment attached to this attribute.
+}
+type integer
+}
+network &Arr{
+concept &Tbl{
+SEED network code is stored here.   SEED uses net/sta/chan/loc to define a
+particular channel of seismic data.   As the name implies this is the top of
+the hierarchy defining the full name of a channel.
+}
+type string
+}
+location &Arr{
+concept &Tbl{
+SEED loc code is stored with this attribute key. SEED uses net/sta/chan/loc to define a
+particular channel of seismic data.  location is the bottom of the hierarchy
+and is relevant only for observatories with more than one sensors.
+}
+type string
+}
+station &Arr{
+concept &Tbl{
+Seismologists have long given name tags to specific seismic observatories.
+SEED uses net/sta/chan/loc to define a particular channel of seismic data.
+station is the core name of a particular site containing one or more sensors.
+}
+type string
+}
+channel &Arr{
+concept &Tbl{
+A channel denotes a particular component of a seismic sensors.
+SEED uses net/sta/chan/loc to define a particular channel of seismic data.
+channel is a key component that defines a particular sensor channel.
+}
+type string
+}
+Ptime &Arr{
+concept &Tbl{
+P wave arrival time stored as epoch time.
+}
+type double
+}
+aliases &Tbl{
+delta dt
+npts ns
+network net
+location loc
+station sta
+channel chan
+starttime t0
+}

--- a/python/tests/test_md.pf
+++ b/python/tests/test_md.pf
@@ -1,0 +1,35 @@
+# This is file is the same one used in antelope contrib.   It contains a good mix of all types
+simple_real_parameter 2.0
+simple_int_parameter 3
+simple_bool_parameter true
+simple_string_parameter test_string
+
+Attribute_Map &Tbl{
+sta sta  wfdisc string
+chan chan  wfdisc string
+time time wfdisc real
+endtime endtime wfdisc real
+nsamp nsamp wfdisc int
+samprate samprate wfdisc real
+directory dir wfdisc string
+file	dfile wfdisc string
+}
+mdlist &Tbl{
+sta string
+chan string
+time real
+#atime real
+endtime real
+nsamp int
+samprate real
+}
+dbprocess_list &Tbl{
+    dbopen wfdisc
+    dbsort sta chan time
+}
+test_nested_tag &Arr{
+    test_double 2.0
+    test_int 4  # Test inline comment
+    test_string foo
+    test_multi_word_string   This is a string with blanks.
+}

--- a/python/tests/test_wrappers.py
+++ b/python/tests/test_wrappers.py
@@ -1,0 +1,93 @@
+import mspasspy as msp
+import math
+import matplotlib.pyplot as plt
+import numpy as np
+
+print('//////////////////Testing of Metadata Related Components///////////')
+pf=msp.AntelopePf('test_md.pf')
+k=pf.keys()
+print('simple parameter keys found=',k)
+print('trying put methods')
+pf.put('testreal',2.0)
+r=pf.get_double('testreal')
+print('put 2.0 get of same=',r)
+pf.put('testint',4)
+i=pf.get_int('testint')
+print('put 4 get of same=',i)
+pf.put('teststring','foo')
+s=pf.get_string('teststring')
+print('put string foo get of same=',s)
+print('keys after put test=',pf.keys())
+print('trying get_tbl')
+tk=pf.tbl_keys()
+ak=pf.arr_keys()
+print('keys for Tbls in this file=',tk)
+print('keys for Arrs in this file=',ak)
+tbl=pf.get_tbl('mdlist')
+print('Extracted this:  ',tbl)
+print('trying get_branch')
+md=pf.get_branch('test_nested_tag')
+print('keys in extracted map=',md.keys())
+print('testing downcast of AntelopePf to Metadata')
+md2=pf.ConvertToMetadata()
+print('type of result=',type(md2))
+print('key of result=',md2.keys())
+mdl=msp.get_mdlist(pf,'mdlist')
+print('MedadataList returned by get_mdlist=',mdl)
+print('///////////Starting tests of TimeSeries /////////////////')
+ts=msp.CoreTimeSeries()
+ts=msp.CoreTimeSeries(4)
+ts.ns=100
+ts.t0=0.0
+ts.dt=0.001
+ts.live=1
+# This is how an enum class sets a value
+ts.tref=msp.TimeReferenceType.Relative
+ts.s.append(1.0)
+ts.s.append(2.0)
+ts.s.append(3.0)
+ts.s.append(4.0)
+print('Test samples with append=',ts.s)
+for i in range(8) :
+    ts.s[i]=i*0.5
+print('Test using indexing operator=',ts.s)
+ts=msp.CoreTimeSeries(100)
+# makes a sine function with approximately one cycle
+for i in range(100) :
+    ts.s[i]=math.sin(6.28*i*0.01)
+#plot routine only handles np array objects so we have to copy for this tests
+a=np.zeros(100)
+for i in range(100) :
+    a[i]=ts.s[i]
+# remove these comments if running interactively.  Not consistent
+# with automated tests on github
+#plt.plot(a)
+#plt.show()
+print('contents of sine wave vector')
+print(ts.s)
+print('///////////Starting tests of Seismogram /////////////////')
+seis=msp.CoreSeismogram()
+seis=msp.CoreSeismogram(100)
+#a=np.arange(15).reshape(3,5)
+#a=np.array([[1,2,3],[4,5,6],[7,8,9],[10,11,12]],np.double)
+#a=np.array([1,2,3,4,5,6,7,8,9,10,11,12],np.double)
+a=np.zeros((3,6),dtype=np.double,order='F')
+ii=1
+for i in range(3):
+    for j in range(6):
+        a[i,j]=ii
+        ii = ii + 1
+print("3x4 data matrix")
+print(a)
+seis.u=msp.dmatrix(a)
+print("component 0 data")
+for i in range(4):
+    print(seis.u[0,i])
+print("component 1 data")
+for i in range(4):
+    print(seis.u[1,i])
+print("component 2 data")
+for i in range(4):
+    print(seis.u[2,i])
+#mddef=msp.MetadataDefinitions('obspy_namespace.pf',PF)
+print("Test completed successfully")

--- a/python/tests/testconverter.py
+++ b/python/tests/testconverter.py
@@ -21,7 +21,6 @@ from obspy2mspass import obspy2mspass
 dout=obspy2mspass(tr,mdef,mdother,aliases)
 print("obspy2mspass completed but test generates a complaint stored in the log")
 print("This is the messsage stored in the TimeSeries log as a complaint")
-elog=dout.get_error_log()
+elog=dout.elog.get_error_log()
 print(elog[0].message)
-print("Done with test of obspy2mspass for TimeSeries")
 # Extension is needed here to test converter to Seismogram - under development

--- a/python/tests/testconverter.py
+++ b/python/tests/testconverter.py
@@ -1,0 +1,27 @@
+from obspy import read
+# copy of example script for fdsn web service retrieval on obspy pages
+# avoids need for saving a data file with the repository
+print("Retrieving ANMO seismogram with obspy fdsn web service client")
+from obspy import UTCDateTime
+from obspy.clients.fdsn import Client
+client = Client("IRIS")
+t = UTCDateTime("2010-02-27T06:45:00.000")
+d = client.get_waveforms("IU", "ANMO", "00", "LHZ", t, t + 60 * 60)
+from mspasspy import MetadataDefinitions
+from mspasspy import MDDefFormat
+print("Loading MetadataDefinitions")
+mdef=MetadataDefinitions("obspy_namespace.pf",MDDefFormat.PF)
+print("success - setting up auxiliary metadata and alias testing")
+tr=d[0]
+mdother=["Ptime","invalid"]
+aliases=["sta"]
+tr.stats["Ptime"]=1000.0
+print("Running obspy2mspass converter for TimeSeries")
+from obspy2mspass import obspy2mspass
+dout=obspy2mspass(tr,mdef,mdother,aliases)
+print("obspy2mspass completed but test generates a complaint stored in the log")
+print("This is the messsage stored in the TimeSeries log as a complaint")
+elog=dout.get_error_log()
+print(elog[0].message)
+print("Done with test of obspy2mspass for TimeSeries")
+# Extension is needed here to test converter to Seismogram - under development


### PR DESCRIPTION
Ian can you have a look at this and see what you think of these changes.  If you think this is ok merge some or all of this to master.  Note that might not be trivial as master has evolved a bit since I forked this from it.   

There are two different changes here:

1. I gave up on getting an answer on the pybind11 issues question about nested classes.  Additional reading convinced me it is probably just not supported because it appears there may be some fundamental clashes with python.   I also realized I was being a purist and there was no real reason for requiring a nested class.  The only reason is the ErrorLogger relation to TimeSeries and Seismogram was a classic example of a "has a" relationship.   It is now an "is a" because I simply made ErrorLogger a parent to MsPASSCoreTS.  TimeSeries and Seismogram now have a pretty complex inheritance diagram with three trunk branches:  one from BasicMetadata, one from BasicTimeSeries, and now one from ErrorLogger.  There is a revised wrapper definition that seems to work based on my test script (more on that below)
2.  I have a partial implementation of an obspy2mspass converter.  It is partial because right now it is only a converter from Trace objects to TimeSeries.   Next step is a converter for three component data.  That presents a slightly different problem as there need to be some rational options for handling orientation.  obspy Trace does not demand orientation information be stored in the Stats header.   I want to make an optional "cardinal" argument that says assume assume you are give three Trace objects in E,N,Z order that are in standard coordinates.   There is also the issue of where you get the optional metadata from when you have three trace objects and the bundle object (can't remember the name right off).   

Finally, I got hung up on this setup for python thing and couldn't figure out how to implement my test scripts into the repository.   You will find these:

1. in mspass/python is the obspy2mspass.py file describe above.
2.  in mspass/python/tests are a set of files that are the test scripts I have been beating on.   They work for me when all these files are copied to mspass/cxx/build/python, but they need to be restructured to make them standard tests.   Look at the README file there for a few more details.

One final note about the tests directory.  There is a crude and partial file to build a test MetadataDefinitions object using a pf format.  Something we need to do soon is standardize that file and put it into the yml format you have (correctly I think) proposed for the schema.   We most definitely need to start filling out the namespace.   Hard for me, in fact, to do the conversion to Seismogram without a decision on how to define orientation - presume we will use hang and vang ala css3.0 as I think iris web services use the same symbols. 