### PR TITLE
Add mdpyconverters

### DIFF
--- a/cxx/include/mspass/utility/Metadata.h
+++ b/cxx/include/mspass/utility/Metadata.h
@@ -282,12 +282,12 @@ other attributes.
   };
 
   /*! Return the keys of all altered Metadata values. */
-  set<string> modified()
+  set<string> modified() const
   {
       return changed_or_set;
   };
   /*! Return all keys without any type information. */
-  set<string> keys() noexcept;
+  set<string> keys() const noexcept;
   /*! Test if a key has an associated value.  Returns true if
    * a value is defined. */
   bool is_defined(const std::string key) const;

--- a/cxx/include/mspass/utility/MetadataDefinitions.h
+++ b/cxx/include/mspass/utility/MetadataDefinitions.h
@@ -104,6 +104,12 @@ public:
   \param aliasname is the the alternative name to define.
   */
   void add_alias(const std::string key, const std::string aliasname);
+  /*! \brief test to see if a key is defind.
+
+  \param key is key to test for a definition.
+  \return true if the key is defined, false otherwise.
+  */
+  bool is_defined(const std::string key) const;
   /*! Standard assignment operator. */
   MetadataDefinitions& operator=(const MetadataDefinitions& parent);
   /*! Accumulate additional definitions.   Appends other to current.

--- a/cxx/python/CMakeLists.txt
+++ b/cxx/python/CMakeLists.txt
@@ -10,6 +10,6 @@ include_directories(
 #add_library(mspasspython STATIC ${sources_python})
 #target_link_libraries(mspasspython PRIVATE mspass ${PYTHON_LIBRARIES})
 
-pybind11_add_module(mspasspy mspass_wrapper.cpp)
+pybind11_add_module(mspasspy mspass_wrapper.cpp MongoDBConverter.cpp)
 
 target_link_libraries(mspasspy PRIVATE mspass)

--- a/cxx/python/MongoDBConverter.cpp
+++ b/cxx/python/MongoDBConverter.cpp
@@ -1,0 +1,181 @@
+#include <stdint.h>
+#include <list>
+#include <set>
+#include "mspass/utility/MsPASSError.h"
+#include "MongoDBConverter.h"
+namespace mspass{
+using namespace mspass;
+using namespace std;
+/* This is a core private method that builds a dict from a MetadataList
+object.  A MetadataList is sensible in C, but awkward for python.   Hence
+we intentionally hide this behind the interface.   There is an inefficiency
+here in returning the dict which will require a least two copy operations
+when any method using this is called.  The assumption, however, is that
+Metadata contents are not huge and this will not be a barrier. This assumption
+could break down if the list of types were allowed to contain larger (in size)
+objects.
+
+An expected common issue is that the list will have keys that are not
+defined in the input Metadata.  Rather than return a more complicated object
+to handle this, all callers need to check the size of the output compared to
+the input and handle that condition as appropriate*/
+py::dict MongoDBConverter::extract_selected(const Metadata& md,
+  const list<string>& keys) const noexcept
+{
+  py::dict result;
+  if(keys.size()<=0) return result;
+  list<string>::const_iterator kptr;
+  for(kptr=keys.begin();kptr!=keys.end();++kptr)
+  {
+    double dval;
+    float fval;
+    int32_t i32val;
+    long int ival;
+    bool bval;
+    string sval;
+    try{
+      string keystr(*kptr);
+      /* pybind11 operator[] for a dict seems to only work with a
+      C char* key.  Use of a std::string creates an errors so we use this
+      pointer to make the logic clearer. */
+      const char *key=keystr.c_str();
+      MDtype mdt=mdef.type(key);
+      switch(mdt)
+      {
+      case MDtype::Real:
+      case MDtype::Real64:
+      case MDtype::Double:
+        dval=md.get<double>(key);
+        result[key]=dval;
+        break;
+      case MDtype::Long:
+      case MDtype::Int64:
+      case MDtype::Integer:
+        ival=md.get<long>(key);
+        result[key]=ival;
+        break;
+      case MDtype::Int32:
+        i32val=md.get<int32_t>(key);
+        result[key]=i32val;
+        break;
+      case MDtype::Real32:
+        fval=md.get<float>(key);
+        result[key]=fval;
+        break;
+      case MDtype::String:
+        sval=md.get<string>(key);
+        result[key]=sval;
+        break;
+      case MDtype::Boolean:
+        /* this one is tricky because of a mismatch with python's rather
+        ridiculous concept of a boolean as a class */
+        bval=md.get<bool>(key);
+        if(bval)
+        {
+          result[key]=py::bool_(true);
+        }
+        else
+        {
+          result[key]=py::bool_(false);
+        }
+        break;
+      case MDtype::Invalid:
+      default:
+        continue;
+      // do nothing for default - should not happen but will lead size mismatch
+      };
+    }catch(...){continue;};  // do nothing if there are errors
+  }
+  return result;
+}
+MongoDBConverter::MongoDBConverter(const std::string mdefname)
+{
+try{
+  mdef=MetadataDefinitions(mdefname);
+}catch(...){throw;};
+}
+py::dict MongoDBConverter::modified(const mspass::Metadata& d) const
+{
+  try{
+    py::dict result;
+    set<string> tochange=d.modified();
+    /* Nothing changing may be common so we return immediately around
+    we return an empty dict in that case.*/
+    if(tochange.size()<=0) return result;
+    /* api mismatch.  Other methods are driven by a list so convenient to
+    convert to a list for this method so a common function can be called. */
+    list<string> clist;
+    set<string>::iterator sptr;
+    for(sptr=tochange.begin();sptr!=tochange.end();++sptr)
+    {
+      clist.push_back(*sptr);
+    }
+    result=this->extract_selected(d,clist);
+    return result;
+  }catch(...){throw;};
+}
+py::dict MongoDBConverter::all(const mspass::Metadata& d) const
+{
+  try{
+    set<string> klist=d.keys();
+    list<string> clist;
+    set<string>::iterator sptr;
+    for(sptr=klist.begin();sptr!=klist.end();++sptr)
+    {
+      clist.push_back(*sptr);
+    }
+    return(this->extract_selected(d,clist));
+  }catch(...){throw;};
+}
+py::dict MongoDBConverter::selected(const mspass::Metadata& d,
+  const py::list& keys, bool noabort) const
+{
+  try{
+    if(keys.size()<=0) return(py::dict());
+    /* We have to convert the python list to an std list */
+    std::list<string> keystd;
+    /* Using this C11 for loop, but may require a cast as not sure if
+    python strings will be cast properly.   */
+    for(auto a : keys)
+    {
+      /* I think this will work because a python string is a child
+      of the base class object where the cast template is defined */
+      string keystr=a.cast<string>();
+      keystd.push_back(keystr);
+    }
+    /* we use the noabort argument to optionally abort if some attributes
+    weren't copies. */
+    py::dict result=this->extract_selected(d,keystd);
+    if(noabort)
+      return result;
+    else
+    {
+      stringstream ss;
+      ss << "MongoDBConverter::selected method: copy error"<<endl
+        << "Input list of keys length="<<keys.size()<<endl
+        << "Output python dict size="<<result.size()<<endl
+        << "Assuming this is an interactive script"<<endl
+        << "Run keys_to_test method, fix the list, and try again"
+        <<endl;
+      throw MsPASSError(ss.str(),ErrorSeverity::Invalid);
+    }
+  }catch(...){throw;};
+}
+py::list MongoDBConverter::badkeys(const Metadata& d,
+  const py::list& keys_to_test) const
+{
+  try{
+    py::list badlist;
+    for(auto a : keys_to_test)
+    {
+      string keystr=a.cast<std::string>();
+      /* Note inverted logic from name - execute when key is not defined */
+      if(!d.is_defined(keystr))
+      {
+        badlist.append(a);
+      }
+    }
+    return badlist;
+  }catch(...){throw;};
+}
+}  // End mspass namespace encapsulation

--- a/cxx/python/MongoDBConverter.h
+++ b/cxx/python/MongoDBConverter.h
@@ -1,0 +1,79 @@
+#ifndef _MONGODB_CONVERTER_H_
+#define _MONGODB_CONVERTER_H_
+#include <string>
+#include <pybind11/pybind11.h>
+#include "mspass/utility/Metadata.h"
+#include "mspass/utility/MetadataDefinitions.h"
+using std::string;
+using mspass::Metadata;
+using mspass::MetadataDefinitions;
+namespace mspass{
+/*! \brief Interface routine to generate python structure for interacting with MongoDB.
+
+The idea behind this class is provide a mechanism for a python script to
+generate CRUD commands to drive MongoDB via pymongo.   The reasons this is
+useful it avoids the need to build an interface to C++ for doing mongodb
+transactions.
+
+Initial focus is Metadata, but the intent is that this object could also
+translate the std::vector used in TimeSeries and/or the dmatrix used in
+Seismogram for serialization into the database.  That will be necessary only if
+we find that approach is efficient enough to be an appropriate approach.
+*/
+namespace py=pybind11;
+class MongoDBConverter
+{
+public:
+  /*! Default constructor.  Loads default MetadataDefinitions. */
+  MongoDBConverter() : mdef(mspass::MetadataDefinitions()){};
+  /*! Construct from an already constructed MetadataDefinitions object. */
+  MongoDBConverter(const mspass::MetadataDefinitions& mdefinition)
+    : mdef(mdefinition){};
+  /*! Construct using a name driven tag that defines a MetadataDefinitions object. */
+  MongoDBConverter(const std::string mdefname);
+  /*! \brief Return all Metadata marked as changed.
+
+  In mspass the Metadata object keeps track of all updates and has methods
+  to establish if an attribute has changed or not.  This method returns
+  only those attributes marked as change.
+
+  \param d is the data object to handle.  Normally a TimeSeries or Seismogram.
+  \return python dictionary that pymongo requires for mongodb CRUD operations
+  \exception a MsPASError is thrown if data for a key marked in Metadata as changed
+  is not present.  That should never happen so it is a major expection marked as fatal.
+  */
+  py::dict modified(const mspass::Metadata& d) const;
+  /*! \brief Return all Metadata for MongoDB CRUD operations.
+
+  This method returns all elements of a data object (normally a TimeSeries
+  or Seismogram cast to Metadata) Metadata as a python dictionary (dict).
+  Such a dictionary is the input pymongo uses for CRUD operations.
+
+  \exception A MsPASError object is thrown if the size of the dict created
+  does not match the size of the original Metadata map.   That should
+  never happen so the returned error is marked Fatal.
+  */
+  py::dict all(const mspass::Metadata& d) const;
+  /*! \brief Return a python dict for CRUD operations driven by a list of keys.
+
+  This method returns a python dict of Metadata defined by a list of keys.
+  Types are sorted out internally.
+  */
+  py::dict selected(const mspass::Metadata& d,
+    const py::list& keys,bool noabort=true) const;
+  /*! Method to find undefined keys.
+
+  This method exists to handle the situation when a call to selected
+  encounters undefined keys.   It returns a list of keys that are indefined.
+  The idea is that this would be used by error handlers. We only define
+  this for python lists assuming a C program would need this functionality*/
+  py::list badkeys(const Metadata& d, const py::list& keys_to_test) const;
+
+private:
+  MetadataDefinitions mdef;
+  py::dict extract_selected(const Metadata& d, const list<std::string>& keys)
+     const noexcept;
+};
+
+} // End mspass namespace scope
+#endif

--- a/cxx/python/MongoDBConverter.h
+++ b/cxx/python/MongoDBConverter.h
@@ -38,29 +38,34 @@ public:
   only those attributes marked as change.
 
   \param d is the data object to handle.  Normally a TimeSeries or Seismogram.
+  \param verbose - when true any nonfatal errors are writen to stderr
+    (use for debugging interactive python scripts)
   \return python dictionary that pymongo requires for mongodb CRUD operations
   \exception a MsPASError is thrown if data for a key marked in Metadata as changed
   is not present.  That should never happen so it is a major expection marked as fatal.
   */
-  py::dict modified(const mspass::Metadata& d) const;
+  py::dict modified(const mspass::Metadata& d,bool verbose) const;
   /*! \brief Return all Metadata for MongoDB CRUD operations.
 
   This method returns all elements of a data object (normally a TimeSeries
   or Seismogram cast to Metadata) Metadata as a python dictionary (dict).
   Such a dictionary is the input pymongo uses for CRUD operations.
+  \param d is the input data object
+  \param verbose - when true any nonfatal errors are writen to stderr
+    (use for debugging interactive python scripts)
 
   \exception A MsPASError object is thrown if the size of the dict created
   does not match the size of the original Metadata map.   That should
   never happen so the returned error is marked Fatal.
   */
-  py::dict all(const mspass::Metadata& d) const;
+  py::dict all(const mspass::Metadata& d,bool verbose) const;
   /*! \brief Return a python dict for CRUD operations driven by a list of keys.
 
   This method returns a python dict of Metadata defined by a list of keys.
   Types are sorted out internally.
   */
   py::dict selected(const mspass::Metadata& d,
-    const py::list& keys,bool noabort=true) const;
+    const py::list& keys,const bool noabort=true,bool verbose=false) const;
   /*! Method to find undefined keys.
 
   This method exists to handle the situation when a call to selected
@@ -71,8 +76,8 @@ public:
 
 private:
   MetadataDefinitions mdef;
-  py::dict extract_selected(const Metadata& d, const list<std::string>& keys)
-     const noexcept;
+  py::dict extract_selected(const Metadata& d, const list<std::string>& keys,
+     bool verbose) const;
 };
 
 } // End mspass namespace scope

--- a/cxx/python/mspass_wrapper.cpp
+++ b/cxx/python/mspass_wrapper.cpp
@@ -14,6 +14,9 @@
 #include <mspass/seismic/Seismogram.h>
 #include <mspass/utility/MetadataDefinitions.h>
 #include <mspass/algorithms/algorithms.h>
+// These includes are objects only visible from the python interpreter
+#include "MongoDBConverter.h"
+// These are the pybind11 required includes
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
@@ -80,6 +83,7 @@ using mspass::pfread;
 using mspass::MDDefFormat;
 using mspass::MetadataDefinitions;
 using mspass::MsPASSCoreTS;
+using mspass::MongoDBConverter;
 using mspass::agc;
 
 /* We enable this gem for reasons explain in the documentation for pybinde11
@@ -495,7 +499,27 @@ PYBIND11_MODULE(mspasspy,m)
     .def(py::init<>())
     .def(py::init<CoreSeismogram,std::string>())
     ;
-  /* For now algorithm functions will go here.  These may eventually be 
+  /* This object is in a separate pair of files in this directory.  */
+  py::class_<mspass::MongoDBConverter>(m,"MongoDBConverter","Metadata translator from C++ object to python")
+      .def(py::init<>())
+      .def(py::init<const mspass::MetadataDefinitions>())
+      .def(py::init<const std::string>())
+      .def("modified",&mspass::MongoDBConverter::modified,
+         py::arg("d"), py::arg("verbose")=false,
+         "Return dict of modified Metadata attributes")
+      .def("selected",&mspass::MongoDBConverter::selected,
+         py::arg("d"),
+         py::arg("keys"),
+         py::arg("noabort")=false,
+         py::arg("verbose")=true,
+         "Return dict of fields defined in input list")
+      .def("all",&mspass::MongoDBConverter::all,
+         py::arg("d"),py::arg("verbose")=true,
+         "Return dict of all Metadata attributes")
+      .def("badkeys",&mspass::MongoDBConverter::badkeys,
+         "Return a python list of any keys that are not defined in input object")
+    ;
+  /* For now algorithm functions will go here.  These may eventually be
      moved to a different module. */
   m.def("agc",&mspass::agc,"Automatic gain control a Seismogram",
     py::return_value_policy::copy,

--- a/cxx/src/lib/utility/Metadata.cc
+++ b/cxx/src/lib/utility/Metadata.cc
@@ -97,10 +97,10 @@ const Metadata Metadata::operator+(const Metadata& other) const
   result += other;
   return result;
 }
-set<string> Metadata::keys() noexcept
+set<string> Metadata::keys() const noexcept
 {
   set<string> result;
-  map<string,boost::any>::iterator mptr;
+  map<string,boost::any>::const_iterator mptr;
   for(mptr=md.begin();mptr!=md.end();++mptr)
   {
     string key(mptr->first);\

--- a/cxx/src/lib/utility/MetadataDefinitions.cc
+++ b/cxx/src/lib/utility/MetadataDefinitions.cc
@@ -173,6 +173,15 @@ std::list<std::string> MetadataDefinitions::keys() const
   }
   return result;
 }
+bool MetadataDefinitions::is_defined(const std::string key) const
+{
+    map<string,mspass::MDtype>::const_iterator tptr;
+    tptr=tmap.find(key);
+    if(tptr==tmap.end())
+        return false;
+    else
+        return true;
+}
 MetadataDefinitions& MetadataDefinitions::operator=(const MetadataDefinitions& parent)
 {
   if(this!=&parent)


### PR DESCRIPTION
This is an important new experimental branch creating an interface class designed as a lower level interface to generate data for CRUD operations in MongoDB.   As I read the documentation creation and updates can be conveniently driven by a python dict.   The new class this branch adds is intended to only be used by python scripts.   It has two primary methods a python script should use:  all - returns all Metadata as a python dict, and selected - returns only Metadata defined in an input python list.   There are some implementation details described in the doxygen comments you should look at critically.  Here is a standalone test script you can use to check this:

from mspasspy import MongoDBConverter
from mspasspy import Metadata
converter=MongoDBConverter()
md=Metadata()
md.put("network","IU")
md.put("station","AAK")
md.put("npts",100)
md.put("not_in_def",2.0)
k=converter.all(d=md)
print(k)
print("bad keys test")
sk=['network','not_in_def','foo']
bk=converter.badkeys(md,sk)
print(bk)
s=['station','npts']
print(s)
x=converter.selected(md,s)
print(x)
print("Testing to sure can be called directly from a Seismogram")
from mspasspy import CoreSeismogram
d=CoreSeismogram(100)
d.put("network","IU")
d.put("npts",100)
k=converter.all(d)
print(k)
