### PR TITLE
Pickle ccore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
           packages:
             - gfortran
             - libboost-dev
+            - libboost-serialization-dev
             - liblapack-dev
       compiler: gcc
       
@@ -50,6 +51,7 @@ jobs:
           packages:
             - gfortran
             - libboost-dev
+            - libboost-serialization-dev
             - liblapack-dev
       compiler: clang
       
@@ -71,6 +73,7 @@ jobs:
           packages:
             - gfortran
             - libboost-dev
+            - libboost-serialization-dev
             - liblapack-dev
             - doxygen
       compiler: gcc

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
        python3-dev python3-pip \
        openjdk-8-jdk \
        git cmake gfortran gdb \
-       liblapack-dev libboost-dev libyaml-dev \
+       liblapack-dev libboost-dev libboost-serialization-dev libyaml-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN pip3 --no-cache-dir install pymongo
 RUN mkdir /home/data
 
 # Prepare the environment
-ENV SPARK_VERSION 2.4.4
+ENV SPARK_VERSION 2.4.5
 ENV SPARK_MASTER_PORT 7077
 
 ENV MSPASS_ROLE master

--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -31,8 +31,7 @@ message (STATUS "YAML_CPP_LIBRARIES   = ${YAML_CPP_LIBRARIES}")
 message (STATUS "YAML_CPP_INCLUDE_DIR = ${YAML_CPP_INCLUDE_DIR}")
 
 
-#find_package (Boost 1.64.0)
-find_package (Boost 1.64.0 REQUIRED COMPONENTS serialization )
+find_package (Boost 1.64.0 COMPONENTS serialization)
 if (NOT Boost_FOUND)
   message (STATUS "Building Boost")
   include (cmake/boost.cmake)
@@ -41,9 +40,8 @@ if (NOT Boost_FOUND)
     ${PROJECT_BINARY_DIR}/boost
     )
 endif ()
-message (STATUS "BOOSTROOT="${BOOSTROOT})
 message (STATUS "Boost_LIBRARIES="${Boost_LIBRARIES})
-message (STATUS "Boost_LIBRARY_DIR_RELEASE="${Boost_LIBRARY_DIR_RELEASE})
+message (STATUS "Boost_LIBRARY_DIRS="${Boost_LIBRARY_DIRS})
 message (STATUS "Boost_INCLUDE_DIRS="${Boost_INCLUDE_DIRS})
 
 find_package (BLAS)

--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -40,9 +40,9 @@ if (NOT Boost_FOUND)
     ${PROJECT_BINARY_DIR}/boost
     )
 endif ()
-message (STATUS "Boost_LIBRARIES="${Boost_LIBRARIES})
-message (STATUS "Boost_LIBRARY_DIRS="${Boost_LIBRARY_DIRS})
-message (STATUS "Boost_INCLUDE_DIRS="${Boost_INCLUDE_DIRS})
+message (STATUS "Boost_LIBRARIES = ${Boost_LIBRARIES}")
+message (STATUS "Boost_LIBRARY_DIRS = ${Boost_LIBRARY_DIRS}")
+message (STATUS "Boost_INCLUDE_DIRS = ${Boost_INCLUDE_DIRS}")
 
 find_package (BLAS)
 if (NOT BLAS_FOUND)

--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -31,7 +31,8 @@ message (STATUS "YAML_CPP_LIBRARIES   = ${YAML_CPP_LIBRARIES}")
 message (STATUS "YAML_CPP_INCLUDE_DIR = ${YAML_CPP_INCLUDE_DIR}")
 
 
-find_package (Boost 1.64.0)
+#find_package (Boost 1.64.0)
+find_package (Boost 1.64.0 REQUIRED COMPONENTS serialization )
 if (NOT Boost_FOUND)
   message (STATUS "Building Boost")
   include (cmake/boost.cmake)
@@ -40,6 +41,10 @@ if (NOT Boost_FOUND)
     ${PROJECT_BINARY_DIR}/boost
     )
 endif ()
+message (STATUS "BOOSTROOT="${BOOSTROOT})
+message (STATUS "Boost_LIBRARIES="${Boost_LIBRARIES})
+message (STATUS "Boost_LIBRARY_DIR_RELEASE="${Boost_LIBRARY_DIR_RELEASE})
+message (STATUS "Boost_INCLUDE_DIRS="${Boost_INCLUDE_DIRS})
 
 find_package (BLAS)
 if (NOT BLAS_FOUND)

--- a/cxx/cmake/boost-download.cmake
+++ b/cxx/cmake/boost-download.cmake
@@ -13,7 +13,7 @@ ExternalProject_Add(
     SHA256=96b34f7468f26a141f6020efb813f1a2f3dfb9797ecf76a7d7cbd843cc95f5bd
   UPDATE_COMMAND wget https://svn.boost.org/trac10/raw-attachment/ticket/11120/python_jam.patch && patch tools/build/src/tools/python.jam python_jam.patch
   CONFIGURE_COMMAND ./bootstrap.sh --prefix=${PROJECT_BINARY_DIR}
-  BUILD_COMMAND ./b2 -j 8
+  BUILD_COMMAND ./b2 cxxflags=-fPIC --with-serialization -j 8
   BUILD_IN_SOURCE 1
   INSTALL_COMMAND ./b2 install
   TEST_COMMAND ""

--- a/cxx/cmake/boost.cmake
+++ b/cxx/cmake/boost.cmake
@@ -21,5 +21,8 @@ macro(fetch_boost _download_module_path _download_root)
         )
 
     set (BOOST_ROOT ${PROJECT_BINARY_DIR}/boost)
-    find_package (Boost 1.71.0 REQUIRED)
+    set (Boost_NO_BOOST_CMAKE ON)
+    set (Boost_USE_STATIC_LIBS ON)
+
+    find_package (Boost 1.71.0 REQUIRED COMPONENTS serialization)
 endmacro()

--- a/cxx/include/mspass/seismic/BasicTimeSeries.h
+++ b/cxx/include/mspass/seismic/BasicTimeSeries.h
@@ -1,6 +1,8 @@
 #ifndef _BASICTIMESERIES_H_
 #define _BASICTIMESERIES_H_
 #include <math.h>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
 namespace mspass{
 /*! \brief Type of time standard for time series data.
 
@@ -122,15 +124,15 @@ of this data object.
   double time_reference() const;
 /*! \brief Force a t0 shift value on data.
  *
- * This is largely an interface routine for constructors that need to 
- * handle data in relative time that are derived from an absolute 
+ * This is largely an interface routine for constructors that need to
+ * handle data in relative time that are derived from an absolute
  * base.  It can also be used to fake processing routines that demand
  * data be in absolute time when the original data were not.  It was
  * added for MsPASS to support reads and writes to MongoDB where we
- * want to be able to read and write data that had been previously 
+ * want to be able to read and write data that had been previously
  * time shifted (e.g. ArrivalTimeReference).
  *
- * \param t is the time shift to force 
+ * \param t is the time shift to force
  * */
 	void force_t0_shift(const double t)
 	{
@@ -187,6 +189,18 @@ private:
     /*When ator or rtoa are called this variable defines the conversion back
      * and forth.  The shift method should be used to change it. */
     double t0shift;
+		friend boost::serialization::access;
+    template<class Archive>
+       void serialize(Archive& ar,const unsigned int version)
+    {
+      ar & live;
+      ar & dt;
+			ar & ns;
+			ar & t0;
+			ar & tref;
+			ar & t0shift_is_valid;
+			ar & t0shift;
+    };
 };
 }
 #endif   // End guard

--- a/cxx/include/mspass/seismic/CoreSeismogram.h
+++ b/cxx/include/mspass/seismic/CoreSeismogram.h
@@ -315,7 +315,7 @@ matrix when the coordinates are cardinal (i.e. ENZ).
 
 \return 3x3 transformation matrix.
 */
-        dmatrix get_transformation_matrix()
+        dmatrix get_transformation_matrix() const
         {
             dmatrix result(3,3);
             for(int i=0;i<3;++i)
@@ -340,6 +340,10 @@ matrix when the coordinates are cardinal (i.e. ENZ).
    not 3x3.
    */
         bool set_transformation_matrix(const dmatrix& A);
+/*! Returns true of components are cardinal. */
+	bool cardinal()const {return components_are_cardinal;};
+/*! Return true if the components are orthogonal. */
+	bool orthogonal()const {return components_are_orthogonal;};
 
 protected:
 	/*!

--- a/cxx/include/mspass/seismic/Seismogram.h
+++ b/cxx/include/mspass/seismic/Seismogram.h
@@ -18,31 +18,31 @@ public:
 
    Most of this class is defined by the CoreSeismogram class, but at present for
    mspass extension we need the objectid for mongdb.  This passes the object id
-   as a string of hex digits.  
+   as a string of hex digits.
 
    \param d is the main CoreSeismogram to be copied.
    \param oid is the objectid specified as a hex string.
    */
   Seismogram(const mspass::CoreSeismogram& d, const std::string oid);
-  /*! Extended partial copy constructor. 
+  /*! Extended partial copy constructor.
 
-  A Seismogram object is created from several pieces.   It can be 
-  useful at times to create a partial clone that copies everything 
+  A Seismogram object is created from several pieces.   It can be
+  useful at times to create a partial clone that copies everything
   but the actual data.   This version clones all components that are
   not data.  Note whenever this constructor is called the object id
-  will automatically be invalid since by definition the object 
+  will automatically be invalid since by definition the object
   created is not stored in the MongoDB database.
 
   \param b - BasicSeismogram component to use to construct data.
-  \param m - Metadata componet to use to construct data (no test are 
+  \param m - Metadata componet to use to construct data (no test are
     made to verify any attributes stored here are consistent with b.
-  \param e - ErrorLogger content.  If these data are derived from a 
-    parent that has an error log (ErrorLogger) that may not be empty 
+  \param e - ErrorLogger content.  If these data are derived from a
+    parent that has an error log (ErrorLogger) that may not be empty
     it can be useful to copy the log.   This argument has a default
     that passes an empty ErrorLog object.   The idea is calling this
     constructor with only two parameters will not copy the error log.
     */
-  Seismogram(const mspass::BasicTimeSeries& b,const mspass::Metadata& m, 
+  Seismogram(const mspass::BasicTimeSeries& b,const mspass::Metadata& m,
           const ErrorLogger elf=ErrorLogger());
 /*! \brief Construct from Metadata and read data from file.
    *
@@ -64,6 +64,27 @@ public:
    \param md is the Metadata object used to drive the constructor.
 
    */
+  /*! \brief Construct from all pieces.
+
+  This constructor build a Seismogram object from all the pieces that define
+  this highest level object in mspass.   This constructor is planned to
+  be hidden from python programmers and not exposed with pybind11 wrappers
+  because is has some potentially undesirable side effects if now used
+  carefully.  The primary purpose of this constructor is for serialization
+  and deserializaton in spark with pickle.  The pickle interface is
+  purely in C for this function so again python programmers don't need
+  to see this constructor.  The parameter names are obvious because
+  they are associated one for one with the objects they are used to
+  construct.  The only exceptions are card and ortho which are booleans
+  used to set the internal booleans components_are_cardinal and
+  components_are_orthogonal respectively (two internals users should not
+  mess with).   tm is also a dmatrix representation the tmatrix stored
+  internally as a 2d C array, but we use the dmatrix to mesh
+  with serialization.
+  */
+  Seismogram(const BasicTimeSeries& b, const Metadata& m,
+    const MsPASSCoreTS& corets,const bool card, const bool ortho,
+    const dmatrix& tm, const dmatrix& uin);
   Seismogram(const Metadata& md);
   /*! Standard copy constructor. */
   Seismogram(const Seismogram& parent)

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -18,32 +18,44 @@ public:
 
    Most of this class is defined by the CoreTimeSeries class, but at present for
    mspass extension we need the objectid for mongdb.  This passes the object id
-   as a string of hex digits.  
+   as a string of hex digits.
 
    \param d is the main CoreTimeSeries to be copied.
    \param oid is the objectid specified as a hex string.
    */
   TimeSeries(const mspass::CoreTimeSeries& d, const std::string oid);
-  /*! Extended partial copy constructor. 
+  /*! Extended partial copy constructor.
 
-  A TimeSeries object is created from several pieces.   It can be 
-  useful at times to create a partial clone that copies everything 
+  A TimeSeries object is created from several pieces.   It can be
+  useful at times to create a partial clone that copies everything
   but the actual data.   This version clones all components that are
   not data.  Note whenever this constructor is called the object id
-  will automatically be invalid since by definition the object 
+  will automatically be invalid since by definition the object
   created is not stored in the MongoDB database.
 
   \param b - BasicTimeSeries component to use to construct data.
-  \param m - Metadata componet to use to construct data (no test are 
+  \param m - Metadata componet to use to construct data (no test are
     made to verify any attributes stored here are consistent with b.
-  \param e - ErrorLogger content.  If these data are derived from a 
-    parent that has an error log (ErrorLogger) that may not be empty 
+  \param e - ErrorLogger content.  If these data are derived from a
+    parent that has an error log (ErrorLogger) that may not be empty
     it can be useful to copy the log.   This argument has a default
     that passes an empty ErrorLog object.   The idea is calling this
     constructor with only two parameters will not copy the error log.
     */
-  TimeSeries(const BasicTimeSeries& b,const Metadata& m, 
+  TimeSeries(const BasicTimeSeries& b,const Metadata& m,
           const ErrorLogger elf=ErrorLogger());
+/*! Special constructor for pickle interface.
+
+The pickle interface required by spark presented problems for MsPASS.  The
+complicated data objects of TimeSeries and Seismogram have to be serialized
+in pieces.   This constructor is only used in the function called
+indirectly by pickle.load.   It essentially contains a TimeSeries dismembered
+into the pieces that can be the serialized independently.   The
+parameters are each associated with one of those required pieces and
+are simply copied to build a valid TimeSeries object in the pickle.load
+function */
+  TimeSeries(const BasicTimeSeries& b,const Metadata& m,
+                  const MsPASSCoreTS& mcts,const vector<double>& d);
   /*! Standard copy constructor. */
   TimeSeries(const TimeSeries& parent)
     : CoreTimeSeries(parent), MsPASSCoreTS(parent){};

--- a/cxx/include/mspass/utility/ErrorLogger.h
+++ b/cxx/include/mspass/utility/ErrorLogger.h
@@ -3,6 +3,10 @@
 #include <unistd.h>
 #include <list>
 #include <list>
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/list.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
 #include "mspass/utility/MsPASSError.h"
 #include "mspass/utility/ErrorLogger.h"
 namespace mspass
@@ -24,6 +28,17 @@ public:
   Note p_id is always fetched with the system call getpid in the constructor.*/
   LogData(const int jid, const std::string alg,const mspass::MsPASSError& merr);
   friend ostream& operator<<(ostream&, LogData&);
+private:
+  friend boost::serialization::access;
+  template<class Archive>
+     void serialize(Archive& ar,const unsigned int version)
+  {
+    ar & job_id;
+    ar & p_id;
+    ar & algorithm;
+    ar & badness;
+    ar & message;
+  };
 };
 /*! \brief Container to hold error logs for a data object.
 
@@ -84,6 +99,13 @@ public:
 private:
   int job_id;
   std::list<LogData> allmessages;
+  friend boost::serialization::access;
+  template<class Archive>
+     void serialize(Archive& ar,const unsigned int version)
+  {
+    ar & job_id;
+    ar & allmessages;
+  };
 };
 } // End mspass namespace
 #endif

--- a/cxx/include/mspass/utility/Metadata.h
+++ b/cxx/include/mspass/utility/Metadata.h
@@ -377,7 +377,7 @@ other attributes.
   };
   */
   /*! Clear data associated with a particular key. */
-  friend ostream& operator<<(ostream&, Metadata&);
+  friend ostringstream& operator<<(ostringstream&, Metadata&);
 protected:
   map<string,boost::any> md;
   /* The keys of any entry changed will be contained here.   */
@@ -473,6 +473,44 @@ from a data object).
 */
 int copy_selected_metadata(const Metadata& mdin, Metadata& mdout,
         const MetadataList& mdlist);
+/*! Serialize Metadata to a string.
+
+This function is needed to support pickle in the python interface.   
+It is called in the pickle definitions in the wrapper for objects using
+Metadata to provide a way to serialize the contents of the Metadata
+object to a string.   The data that string contains is expected to 
+restored with the inverse of this function called restore.  
+
+Serialized output is readable with each entry on one line with 
+this format:
+key type value
+where type is restricted to double, long, bool, and the long C++ name for 
+an std::string.  Currently this:
+std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >
+
+Note any entry not of the four supported types will generate an error message
+posted to stderr.   That is an ugly approach, but an intentional design 
+decision as this function should normally be called only pickling 
+methods for data objects.   Could see no solution to save errors in 
+that environment without throwing an exception and aborting the processing.
+
+\param md is the Metadata object to be serialized
+\return std::string of serialized data.  
+*/
+std::string serialize(const Metadata& md);
+/*! Unpack serialized Metadata.
+ *
+This function is the inverse of the serialize function.   It recreates a
+Metadata object serialized previous with the serialize function.  Note it 
+only supports basic types currently supported by mspass:  long ints, double,
+boolean, and string.  Since the output is assumed to be form serialize we
+do not test for validity of the type assuming serialize didn't handle 
+anything else.
+
+\param sd is the serialized data to be unpacked
+\return Metadata derived from sd
+*/
+Metadata restore_serialized(const std::string);
 
 }  //End of namespace MsPASS
 #endif

--- a/cxx/include/mspass/utility/Metadata.h
+++ b/cxx/include/mspass/utility/Metadata.h
@@ -345,15 +345,15 @@ other attributes.
   };
   /*! \brief Mark all data as unmodified.
    *
-   * There are situations where it is necessary to clear the 
+   * There are situations where it is necessary to clear the
    * data structure used to mark changed metadata.  The best
    * example know is when data objects interact with a database
    * and try to do updates.   Effort can be wasted in unnecessary
-   * updates if metadata are improperly marked as modified.   
+   * updates if metadata are improperly marked as modified.
    * This method clears the entire container that defines
-   * changed data. 
+   * changed data.
    * */
-  void clear_modified() 
+  void clear_modified()
   {
 	  changed_or_set.clear();
   };
@@ -406,7 +406,7 @@ template <typename T> T Metadata::get(const string key) const
  *
  * We use a boost::any object as a container to hold any generic object.
  * The type name is complicated by name mangling.  This small function
- * returns a human readable type name.  
+ * returns a human readable type name.
  *
  * \param val is the boost::any container to be checked for type.
  * \return demangled name of type of the entity stored in the container.
@@ -475,42 +475,42 @@ int copy_selected_metadata(const Metadata& mdin, Metadata& mdout,
         const MetadataList& mdlist);
 /*! Serialize Metadata to a string.
 
-This function is needed to support pickle in the python interface.   
+This function is needed to support pickle in the python interface.
 It is called in the pickle definitions in the wrapper for objects using
 Metadata to provide a way to serialize the contents of the Metadata
-object to a string.   The data that string contains is expected to 
-restored with the inverse of this function called restore.  
+object to a string.   The data that string contains is expected to
+restored with the inverse of this function called restore.
 
-Serialized output is readable with each entry on one line with 
+Serialized output is readable with each entry on one line with
 this format:
 key type value
-where type is restricted to double, long, bool, and the long C++ name for 
+where type is restricted to double, long, bool, and the long C++ name for
 an std::string.  Currently this:
 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >
 
 Note any entry not of the four supported types will generate an error message
-posted to stderr.   That is an ugly approach, but an intentional design 
-decision as this function should normally be called only pickling 
-methods for data objects.   Could see no solution to save errors in 
+posted to stderr.   That is an ugly approach, but an intentional design
+decision as this function should normally be called only pickling
+methods for data objects.   Could see no solution to save errors in
 that environment without throwing an exception and aborting the processing.
 
 \param md is the Metadata object to be serialized
-\return std::string of serialized data.  
+\return std::string of serialized data.
 */
-std::string serialize(const Metadata& md);
+std::string serialize_metadata(const Metadata& md);
 /*! Unpack serialized Metadata.
  *
 This function is the inverse of the serialize function.   It recreates a
-Metadata object serialized previous with the serialize function.  Note it 
+Metadata object serialized previous with the serialize function.  Note it
 only supports basic types currently supported by mspass:  long ints, double,
 boolean, and string.  Since the output is assumed to be form serialize we
-do not test for validity of the type assuming serialize didn't handle 
+do not test for validity of the type assuming serialize didn't handle
 anything else.
 
 \param sd is the serialized data to be unpacked
 \return Metadata derived from sd
 */
-Metadata restore_serialized(const std::string);
+Metadata restore_serialized_metadata(const std::string);
 
 }  //End of namespace MsPASS
 #endif

--- a/cxx/include/mspass/utility/MsPASSCoreTS.h
+++ b/cxx/include/mspass/utility/MsPASSCoreTS.h
@@ -1,18 +1,20 @@
 #ifndef _MSPASS_CORE_TS_H_
 #define _MSPASS_CORE_TS_H_
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
 #include "mspass/utility/ErrorLogger.h"
 namespace mspass{
 /*! \brief Common components for interaction with MsPASS.
 
 This class is intended to be provide common API elements for data objects to interact with
 MsPASS framework.   It contains elements needed by the data to interact seamlessly with MongoDB and
-spark.  
+spark.
 
 This implementation assumes most database manipulations will take place in python scripts.  That
-means the actual contents of this object are minimal.  For the initial implementation the main 
+means the actual contents of this object are minimal.  For the initial implementation the main
 hook is the string that is used in MongoDB as an external form fo the ObjectID.   This assumption
-is the get and put methods for the objectid string will be sufficient for a python wrapper to 
-associate data with the a unique document in the database.   
+is the get and put methods for the objectid string will be sufficient for a python wrapper to
+associate data with the a unique document in the database.
 */
 class MsPASSCoreTS
 {
@@ -46,6 +48,13 @@ class MsPASSCoreTS
     /*! ObjectID hex string.   Can be converted readily to form needed to
     find a document. */
     string hex_id;
+    friend boost::serialization::access;
+    template<class Archive>
+       void serialize(Archive& ar,const unsigned int version)
+    {
+      ar & hex_id;
+      ar & elog;
+    };
 };
 }  //End Namespace mspass
 #endif

--- a/cxx/include/mspass/utility/dmatrix.h
+++ b/cxx/include/mspass/utility/dmatrix.h
@@ -4,6 +4,12 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+/* Either text or binary can be specified here, but we use binary
+ * to emphasize this class is normally serialized binary for 
+ * speed*/
+#include <boost/serialization/vector.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
 #include "mspass/utility/MsPASSError.h"
 namespace mspass
 {
@@ -256,6 +262,14 @@ protected:
    vector<double> ary;   // initial size of container 0
    int length;
    int nrr, ncc;
+private:
+   friend class boost::serialization::access;
+   template<class Archive>void serialize(Archive & ar,
+                           const unsigned int version)
+   {
+       ar & nrr & ncc & length;
+       ar & ary;
+   }
 };
 /*! \brief A vector compatible with dmatrix objects.
  

--- a/cxx/python/CMakeLists.txt
+++ b/cxx/python/CMakeLists.txt
@@ -12,5 +12,5 @@ include_directories(
 
 pybind11_add_module(ccore mspass_wrapper.cpp MongoDBConverter.cpp)
 
-target_link_libraries(ccore PRIVATE mspass)
+target_link_libraries(ccore PRIVATE mspass ${Boost_LIBRARIES})
 

--- a/cxx/python/mspass_wrapper.cpp
+++ b/cxx/python/mspass_wrapper.cpp
@@ -572,9 +572,14 @@ PYBIND11_MODULE(ccore,m)
         stringstream sstm;
         boost::archive::text_oarchive artm(sstm);
         artm<<tmatrix;
+        /* This is a very slow solution, but using the axiom make it work
+        before you make it fast*/
+        stringstream ssu;
+        boost::archive::text_oarchive aru(ssu);
+        aru<<self.u;
         return py::make_tuple(sbuf,ssbts.str(),sscorets.str(),
           cardinal, orthogonal,sstm.str(),
-          self.u);
+          ssu.str());
       },
       [](py::tuple t) {
        string sbuf=t[0].cast<std::string>();
@@ -594,7 +599,11 @@ PYBIND11_MODULE(ccore,m)
        boost::archive::text_iarchive artm(sstm);
        dmatrix tmatrix;
        artm>>tmatrix;
-       return Seismogram(bts,md,corets,cardinal,orthogonal,tmatrix,t[6].cast<dmatrix&>());
+       stringstream ssu(t[6].cast<std::string>());
+       boost::archive::text_iarchive aru(ssu);
+       dmatrix u;
+       aru>>u;
+       return Seismogram(bts,md,corets,cardinal,orthogonal,tmatrix,u);
      }
      ))
     ;

--- a/cxx/python/mspass_wrapper.cpp
+++ b/cxx/python/mspass_wrapper.cpp
@@ -615,9 +615,9 @@ PYBIND11_MODULE(ccore,m)
           stringstream sscorets;
           boost::archive::text_oarchive arcorets(sscorets);
           arcorets<<dynamic_cast<const MsPASSCoreTS&>(self);
-          /*This creates a numpy array of length ns to hold data */
-          py::array_t<double, py::array::f_style> darr(self.ns);
-          for(int i=0;i<self.ns;++i) darr.mutable_at(i)=self.s[i];
+          /*This creates a numpy array alias from the vector container
+          without a move or copy of the data */
+          py::array_t<double, py::array::f_style> darr(self.ns,&(self.s[0]));
           return py::make_tuple(sbuf,ssbts.str(),sscorets.str(),darr);
         },
         [](py::tuple t) {

--- a/cxx/src/lib/seismic/CoreTimeSeries.cc
+++ b/cxx/src/lib/seismic/CoreTimeSeries.cc
@@ -30,6 +30,16 @@ CoreTimeSeries::CoreTimeSeries(const CoreTimeSeries& tsi) :
     {
         s=tsi.s;
     }
+    else if(tsi.s.size()>0)
+    {
+      /* This is needed to preserve the contents of data vector when something
+      marks the data dead, but one wants to restore it later.  Classic example
+      is an interactive trace editor.  Found mysterious errors can occur
+      without this features. */
+        s=tsi.s;
+    }
+    /* Do nothing if the parent s is empty as std::vector will be properly
+    initialized*/
 }
 
 CoreTimeSeries::CoreTimeSeries(const BasicTimeSeries& bd,const Metadata& md)
@@ -47,10 +57,7 @@ CoreTimeSeries& CoreTimeSeries::operator=(const CoreTimeSeries& tsi)
     {
         this->BasicTimeSeries::operator=(tsi);
         this->Metadata::operator=(tsi);
-        if(tsi.live)
-        {
-            s=tsi.s;
-        }
+        s=tsi.s;
     }
     return(*this);
 }

--- a/cxx/src/lib/seismic/Seismogram.cc
+++ b/cxx/src/lib/seismic/Seismogram.cc
@@ -3,7 +3,7 @@ using namespace mspass;
 namespace mspass
 {
 Seismogram::Seismogram(const CoreSeismogram& d, const std::string oid)
-    : CoreSeismogram(d)
+    : CoreSeismogram(d),MsPASSCoreTS()
 {
     try{
         this->set_id(oid);
@@ -12,7 +12,7 @@ Seismogram::Seismogram(const CoreSeismogram& d, const std::string oid)
 Seismogram::Seismogram(const BasicTimeSeries& b, const Metadata& m,
         const ErrorLogger elf)
 {
-    /* Have to use this construct instead of : and a pair of 
+    /* Have to use this construct instead of : and a pair of
        copy constructors for Metadata and BasicSeismogram.   Compiler
        complains they are not a direct or virtual base for Seismogram.  */
     this->BasicTimeSeries::operator=(b);
@@ -20,13 +20,33 @@ Seismogram::Seismogram(const BasicTimeSeries& b, const Metadata& m,
     elog=elf;
     this->set_id("INVALID");
 }
+Seismogram::Seismogram(const BasicTimeSeries& b, const Metadata& m,
+  const MsPASSCoreTS& corets,const bool card, const bool ortho,
+  const dmatrix& tm, const dmatrix& uin)
+    : CoreSeismogram(),MsPASSCoreTS(corets)
+{
+  /* for reasons I couldn't figure out these couldn't appear in the copy
+  constructor chain following the : above.   Compiler complained about
+  these not being a direct base.  Sure there is a way to fix that, but
+  the difference in calling operator= like here is next to nothing.*/
+  BasicTimeSeries bts=dynamic_cast<BasicTimeSeries&>(*this);
+  bts=mspass::BasicTimeSeries::operator=(b);
+  Metadata mdthis=dynamic_cast<Metadata&>(*this);
+  mdthis=mspass::Metadata::operator=(m);
+  components_are_cardinal=card;
+  components_are_orthogonal=ortho;
+  int i,j;
+  for(i=0;i<3;++i)
+    for(j=0;j<3;++j) tmatrix[i][j]=tm(i,j);
+  this->u=uin;
+}
 Seismogram::Seismogram(const Metadata& md)
 	: CoreSeismogram(md,true),MsPASSCoreTS()
 {
   /* We use oid_string to hold the ObjectID stored as a hex string.
    * In mspass this is best done in the calling python function
-   * that already has hooks for mongo.   If that field is not 
-   * defined we silently set the id invalid.   
+   * that already has hooks for mongo.   If that field is not
+   * defined we silently set the id invalid.
    */
   try{
     string oids=this->get_string("oid_string");

--- a/cxx/src/lib/seismic/TimeSeries.cc
+++ b/cxx/src/lib/seismic/TimeSeries.cc
@@ -12,13 +12,25 @@ TimeSeries::TimeSeries(const CoreTimeSeries& d, const std::string oid)
 TimeSeries::TimeSeries(const BasicTimeSeries& b, const Metadata& m,
         const ErrorLogger elf)
 {
-    /* Have to use this construct instead of : and a pair of 
+    /* Have to use this construct instead of : and a pair of
        copy constructors for Metadata and BasicTimeSeries.   Compiler
        complains they are not a direct or virtual base for TimeSeries.  */
     this->BasicTimeSeries::operator=(b);
     this->Metadata::operator=(m);
     elog=elf;
     this->set_id("INVALID");
+}
+/* this is kind of a weird construct because the pieces are assembled
+out of the regular order of an object created by inheritance.  I hope
+that does not cause problems. */
+TimeSeries::TimeSeries(const BasicTimeSeries& b, const Metadata& m,
+  const MsPASSCoreTS& mcts,const vector<double>& d)
+     : MsPASSCoreTS(mcts)
+{
+  /* This seems necessary due to ambiguities of multiple inheritance. */
+  this->BasicTimeSeries::operator=(b);
+  this->Metadata::operator=(m);
+  this->s=d;
 }
 TimeSeries& TimeSeries::operator=(const TimeSeries& parent)
 {

--- a/cxx/src/lib/utility/Metadata.cc
+++ b/cxx/src/lib/utility/Metadata.cc
@@ -227,7 +227,7 @@ ostringstream& operator<<(ostringstream& os, Metadata& m)
 }
 /* This function is very much like operator<< except it is more
  * restricted on allowed types and it add a type name to the output */
-std::string serialize(const Metadata& md)
+std::string serialize_metadata(const Metadata& md)
 {
   try{
     ostringstream ss;
@@ -240,7 +240,7 @@ std::string serialize(const Metadata& md)
 /* This has a lot more complexity but assumes a series of lines
  * defined by ostringstream operator:  key, type, value
  * */
-Metadata restore_serialized(const std::string s)
+Metadata restore_serialized_metadata(const std::string s)
 {
   try{
     stringstream ss(s);

--- a/cxx/test/md/CMakeLists.txt
+++ b/cxx/test/md/CMakeLists.txt
@@ -6,4 +6,4 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/include/)
 
-target_link_libraries(test_md PRIVATE -L/opt/boost/lib mspass boost_serialization)
+target_link_libraries(test_md PRIVATE mspass ${Boost_LIBRARIES})

--- a/cxx/test/md/CMakeLists.txt
+++ b/cxx/test/md/CMakeLists.txt
@@ -6,4 +6,4 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/include/)
 
-target_link_libraries(test_md PRIVATE mspass)
+target_link_libraries(test_md PRIVATE -L/opt/boost/lib mspass boost_serialization)

--- a/cxx/test/md/test_md.cc
+++ b/cxx/test/md/test_md.cc
@@ -1,3 +1,4 @@
+#include <boost/archive/text_oarchive.hpp>
 #include "mspass/utility/ErrorLogger.h"
 #include "mspass/utility/MsPASSError.h"
 #include "mspass/utility/Metadata.h"
@@ -44,14 +45,14 @@ int main(int argc, char **argv)
 		ss << mdplain;
 		cout << "Succeeded - stringstream contents:"<<endl;
 		cout << ss.str()<<endl;
-		cout<< "Trying same with serialize function"<<endl;
-		string sbuf=serialize(mdplain);
+		cout<< "Trying same with serialize_metadata function"<<endl;
+		string sbuf=serialize_metadata(mdplain);
 		cout<<"Serialized completed: content "<<endl
 			<<"(should be same as stringstream output above)"<<endl;
 		cout <<sbuf;
-		cout << "Trying to run inverse function restore_serialized "
+		cout << "Trying to run inverse function restore_serialized_metadata "
 			<<"on sterialization output"<<endl;
-		Metadata mrestored=restore_serialized(sbuf);
+		Metadata mrestored=restore_serialized_metadata(sbuf);
 		cout<<"Result - should again be the same"<<endl;
 		print_metadata(mrestored);
                 cout << "Same thing using operator >> to cout"<<endl;
@@ -162,6 +163,24 @@ int main(int argc, char **argv)
                 {
                     cout << *lptr<<endl;
                 }
+		cout << "Testing serialization of error log"<<endl;
+		stringstream serial_ss;
+		boost::archive::text_oarchive ar(serial_ss);
+		ar << elog;
+		cout << "serialization finished"<<endl;
+		cout << "Attempting to restore"<<endl;
+		string serialbuf=serial_ss.str();
+		istringstream eloginstrm(serialbuf);
+		ErrorLogger elog_restored;
+		boost::archive::text_iarchive arin(eloginstrm);
+		arin>>elog_restored;
+		cout << "Error log restored - contents should match above"<<endl;
+		ldata=elog_restored.get_error_log();
+		for(lptr=ldata.begin();lptr!=ldata.end();++lptr)
+                {
+                    cout << *lptr<<endl;
+                }
+
 	}
 	catch (MsPASSError& sess)
 	{

--- a/cxx/test/md/test_md.cc
+++ b/cxx/test/md/test_md.cc
@@ -3,6 +3,12 @@
 #include "mspass/utility/Metadata.h"
 #include "mspass/utility/AntelopePf.h"
 using namespace mspass;
+void print_metadata(Metadata& md)
+{
+  ostringstream ss;
+  ss << md;
+  cout << ss.str();
+}
 int main(int argc, char **argv)
 {
 	char *pfname=strdup("test_md.pf");
@@ -33,8 +39,23 @@ int main(int argc, char **argv)
                 cout << "double_val="<<mdplain.get<double>("double_val")<<endl;
                 cout << "string_val="<<mdplain.get<string>("string_val")<<endl;
                 cout << "bool_val="<<mdplain.get<bool>("bool_val")<<endl;
-                cout << "Same thing using operator >> "<<endl;
-		cout << mdplain;
+		ostringstream ss;
+		cout << "Trying to serialize with operator stringstream"<<endl;
+		ss << mdplain;
+		cout << "Succeeded - stringstream contents:"<<endl;
+		cout << ss.str()<<endl;
+		cout<< "Trying same with serialize function"<<endl;
+		string sbuf=serialize(mdplain);
+		cout<<"Serialized completed: content "<<endl
+			<<"(should be same as stringstream output above)"<<endl;
+		cout <<sbuf;
+		cout << "Trying to run inverse function restore_serialized "
+			<<"on sterialization output"<<endl;
+		Metadata mrestored=restore_serialized(sbuf);
+		cout<<"Result - should again be the same"<<endl;
+		print_metadata(mrestored);
+                cout << "Same thing using operator >> to cout"<<endl;
+		print_metadata(mdplain);
 		cout << "Testing is_defined and clear methods"<<endl;
 		cout << "This should be a False(0) (undefined key)->"
 			<<mdplain.is_defined("HUHLigh")<<endl;
@@ -47,26 +68,26 @@ int main(int argc, char **argv)
 		else
 			cout << "Test of clear method succeeded"<<endl;
 		cout << "Contents of edited mdplain"<<endl;
-		cout << mdplain<<endl;
+		print_metadata(mdplain);
 		cout << "Trying simple file read constructor"<<endl
                     << "Reading from simple.txt"<<endl;
                 ifstream ifs("simple.txt");
                 Metadata mds(ifs);
-		cout << mds;
+		print_metadata(mds);
                 cout << "Trying to read more complex pf file using AntelopePF object constructor"<<endl;
                 AntelopePf pfsmd(pfname);
-                cout << "Success - read the following:  "<<endl
-                    << pfsmd<<endl;
+                cout << "Success - read the following:  "<<endl;
+		print_metadata(pfsmd);
                 cout << "Trying assignment operator for Metadata with RTTI"<<endl;
                 Metadata mdsum;
                 mdsum=dynamic_cast<Metadata&>(pfsmd);
                 cout << "Worked"<<endl<<"Contents of copy (simple attributes ony)"<<endl;
-                cout << mdsum<<endl;
+		print_metadata(mdsum);
                 cout << "Trying += operator.  Merging inline and pf objects"<<endl;
                 cout << "Trying to add simple to Metadata derived from pf"<<endl;
                 mdsum+=mds;
                 cout << "Done - result:"<<endl;
-                cout << mdsum<<endl;
+		print_metadata(mdsum);
                 cout << "Reading and writing a couple of simple parameters"<<endl;
                 cout << "simple_real_parameter="
                     <<pfsmd.get<double>("simple_real_parameter")<<endl
@@ -87,8 +108,8 @@ int main(int argc, char **argv)
                   <<endl;
                 AntelopePf pfbr(pfsmd.get_branch("test_nested_tag"));
                 cout << "Success"<<endl
-                    <<"Contents"<<endl
-                    << dynamic_cast<Metadata&>(pfbr)<<endl;
+                    <<"Contents"<<endl;
+		print_metadata(pfbr);
                 cout << "test_double parameter in branch="<<pfbr.get_double("test_double")<<endl;
                 cout << "Testing exceptions.  First a get failure:"<<endl;
                 try{


### PR DESCRIPTION
Ian, I think this branch is now ready to merge.   pickle is working now for both Seismogram and TimeSeries objects with the caveats you will see in the issues section on serialization issues.  

Here is a little test script you can use to validate this - you will need to modify the sys.append.path as I'm using that approach right now for handling the ccore library.  Also you may need to set LD_LIBRARY_PATH to the location of boost libraries.    Here is the script:
```
import sys
sys.path.append('/home/pavlis/src/mspass/python')
from mspasspy.ccore import CoreSeismogram
d=CoreSeismogram(200)
d.put_double('delta',1.0)
d.put_double('dt',1.0)
d.put('npts',200)
d.ns=200
d.t0=100.0
d.live=True
from mspasspy.ccore import Seismogram
d2=Seismogram(d,'invalid')
import pickle
x=pickle.dumps(d2)
print("pickle succeeded")
print("trying to restore")
d3=pickle.loads(x)
print("pickle loads completed")
print("data npts=",d.get_int('npts'))
print('same stored in struct of BasicTimeSeries=',d.ns)
print('data t0=',d.t0)
print('Now testing pickle for TimeSeries data')
from mspasspy.ccore import TimeSeries
from mspasspy.ccore import CoreTimeSeries
d0=CoreTimeSeries(500)
d0.live=True
d0.dt=1.0
d0.ns=500
d=TimeSeries(d0,'invalid')
s=pickle.dumps(d)
print('Pickle dumps succeeded')
print('size of string returned by pickle=',len(s))
print('Trying loads')
dr=pickle.loads(s)
print('Finished - BasicTimeSeries attributes in output')
print('ns=',dr.ns)
print('dt=',dr.dt)
print('t0=',dr.t0)
```