### PR TITLE
Cleanup core c api

### DIFF
--- a/cxx/include/mspass/seismic/CoreSeismogram.h
+++ b/cxx/include/mspass/seismic/CoreSeismogram.h
@@ -37,7 +37,8 @@ done, for example, with std::basic_string made equivalent to std::string.
  through inheritance of a Metadata object.
 \author Gary L. Pavlis
 **/
-class CoreSeismogram : public mspass::seismic::BasicTimeSeries , public mspass::utility::Metadata
+class CoreSeismogram : virtual public mspass::seismic::BasicTimeSeries,
+              virtual public mspass::utility::Metadata
 {
 public:
  /*!
@@ -138,7 +139,8 @@ Initializes data and sets aside memory for
 
  \exception  Will throw a MsPASSError if required metadata are missing.
  */
-        CoreSeismogram(const mspass::utility::Metadata& md,const bool load_data=true);
+ CoreSeismogram(const mspass::utility::Metadata& md,const bool load_data=true);
+
 /*!
  Standard copy constructor.
 **/

--- a/cxx/include/mspass/seismic/CoreSeismogram.h
+++ b/cxx/include/mspass/seismic/CoreSeismogram.h
@@ -37,8 +37,8 @@ done, for example, with std::basic_string made equivalent to std::string.
  through inheritance of a Metadata object.
 \author Gary L. Pavlis
 **/
-class CoreSeismogram : virtual public mspass::seismic::BasicTimeSeries,
-              virtual public mspass::utility::Metadata
+class CoreSeismogram : public mspass::seismic::BasicTimeSeries,
+              public mspass::utility::Metadata
 {
 public:
  /*!
@@ -146,6 +146,7 @@ Initializes data and sets aside memory for
 **/
 
 	CoreSeismogram(const CoreSeismogram&);
+
 	/* These overload virtual methods in BasicTimeSeries. */
 	/*! \brief Set the sample interval.
 
@@ -254,7 +255,7 @@ to an exception if the the time requested is outside the data range.
 */
         std::vector<double> operator[](const double time)const;
 /*! Standard destructor. */
-	~CoreSeismogram(){};
+	virtual ~CoreSeismogram(){};
 /*!
  Apply inverse transformation matrix to return data to cardinal direction components.
 

--- a/cxx/include/mspass/seismic/CoreTimeSeries.h
+++ b/cxx/include/mspass/seismic/CoreTimeSeries.h
@@ -39,9 +39,17 @@ or push_front applied to this vector will alter it's length
 so use this only if the size of the data to fill the object is
 already known.
 **/
-	CoreTimeSeries(size_t nsin);
-/*! Construct from components. */
-        CoreTimeSeries(const BasicTimeSeries& bts,const Metadata& md);
+	CoreTimeSeries(const size_t nsin);
+/*! Partially construct from components.
+
+There are times one wants to use the Metadata area as a template to
+flesh out a CoreTimeSeries as what might be called skin and bones:  skin is
+Metadata and bones as BasicTimeSeries data.   This constructor initializes
+those two base classes but does not fully a valid data vector.  It only
+attempts to fetch the number of points expected for the data vector using
+the npts metadata (integer) key (i.e. it sets npts to md.get_int("npts")).
+It then creates the data vector of that length and initialzies it to all zeros.*/
+  CoreTimeSeries(const BasicTimeSeries& bts,const Metadata& md);
 /*!
 Standard copy constructor.
 **/

--- a/cxx/include/mspass/seismic/CoreTimeSeries.h
+++ b/cxx/include/mspass/seismic/CoreTimeSeries.h
@@ -13,8 +13,8 @@ that aren't essential to define the data object, but which are necessary
 for some algorithms.
 \author Gary L. Pavlis
 **/
-class CoreTimeSeries: virtual public mspass::seismic::BasicTimeSeries,
-    virtual public mspass::utility::Metadata
+class CoreTimeSeries: public mspass::seismic::BasicTimeSeries,
+    public mspass::utility::Metadata
 {
 public:
 /*!

--- a/cxx/include/mspass/seismic/CoreTimeSeries.h
+++ b/cxx/include/mspass/seismic/CoreTimeSeries.h
@@ -13,7 +13,8 @@ that aren't essential to define the data object, but which are necessary
 for some algorithms.
 \author Gary L. Pavlis
 **/
-class CoreTimeSeries: public mspass::seismic::BasicTimeSeries , public mspass::utility::Metadata
+class CoreTimeSeries: virtual public mspass::seismic::BasicTimeSeries,
+    virtual public mspass::utility::Metadata
 {
 public:
 /*!

--- a/cxx/include/mspass/seismic/Seismogram.h
+++ b/cxx/include/mspass/seismic/Seismogram.h
@@ -14,6 +14,15 @@ class Seismogram : virtual public mspass::seismic::CoreSeismogram,
    public mspass::utility::ProcessingHistory
 {
 public:
+  /*! Error logging object.
+
+  In MsPASS we use an error logger attached to atomic data objects to
+  provide a mechanism to move nonfatal errors along with data.  This allows
+  errors to be posted in a parallel environment and not be lost of jumbled
+  up by simultaneous writes by multiple threads to the same buffer
+  (stdio functions, for example, aren't thread safe and have that issue)
+  */
+  mspass::utility::ErrorLogger elog;
   /*! Default constructor.   Only runs subclass default constructors. */
   Seismogram() : mspass::seismic::CoreSeismogram(),mspass::utility::ProcessingHistory(){};
   /*! Bare bones constructor allocates space and little else.
@@ -87,7 +96,8 @@ internally as a 2d C array, but we use the dmatrix to mesh
 with serialization.
 */
   Seismogram(const mspass::seismic::BasicTimeSeries& b, const mspass::utility::Metadata& m,
-    const mspass::utility::ProcessingHistory& his,
+    const mspass::utility::ErrorLogger& elg,
+     const mspass::utility::ProcessingHistory& his,
       const bool card, const bool ortho,
         const mspass::utility::dmatrix& tm, const mspass::utility::dmatrix& uin);
   /*! Constructor driven by a Metadata object.

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -15,6 +15,41 @@ class TimeSeries : public mspass::seismic::CoreTimeSeries,
 public:
   /*! Default constructor.   Only runs subclass default constructors. */
   TimeSeries() : mspass::seismic::CoreTimeSeries(),mspass::utility::ProcessingHistory(){};
+  /*! Bare bones constructor allocates space and little else.
+
+  Sometimes it is helpful to construct a skeleton that can be fleshed out
+  manually.   This constructor allocates an nsamples vector and
+  initializes it to all zeros.   The data are marked dead
+  because the assumption is the caller will fill out commonly needed basic
+  Metadata, load some kind of sample data into the data vector, and then
+  call the set_live method when that process is completed.   That kind of
+  manipulation is most common in preparing simulation or test data where
+  the common tags on real data do not exist and need to be defined manually
+  for the simulatioon or test.   The history section is initialized with
+  the default constructor, which currently means it is empty.   If a simulation
+  or test requires a history origin the user must load it manaually.
+
+  \param nsamples is the number of samples needed for storing the data vector.
+    */
+  TimeSeries(const size_t nsamples) : mspass::seismic::CoreTimeSeries(nsamples),
+      mspass::utility::ProcessingHistory(){};
+  /*! Partially construct from components.
+
+      There are times one wants to use the Metadata area as a template to
+      flesh out a CoreTimeSeries as what might be called skin and bones:  skin is
+      Metadata and bones as BasicTimeSeries data.   This constructor initializes
+      those two base classes but does not fully a valid data vector.  It only
+      attempts to fetch the number of points expected for the data vector using
+      the npts metadata (integer) key (i.e. it sets npts to md.get_int("npts")).
+      It then creates the data vector of that length and initialzies it to all zeros.
+
+      This constructor is largely a wrapper for the CoreTimeSeries version
+      with the same signature but it also initalizes the ProcessingHistory
+      to null (calling the default constructor)*/
+  TimeSeries(const BasicTimeSeries& bts,const Metadata& md)
+      : CoreTimeSeries(bts,md),ProcessingHistory()
+  {};
+
   /*!  \brief Construct from lower level CoreTimeSeries.
 
   In MsPASS CoreTimeSeries has the primary functions that define the

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -9,7 +9,7 @@ namespace mspass::seismic{
   in the MsPASS framework.   It extends CoreTimeSeries by adding
   common MsPASS components (ProcessingHistory).  It may evolve with additional
   special features.  */
-class TimeSeries : virtual public mspass::seismic::CoreTimeSeries,
+class TimeSeries : public mspass::seismic::CoreTimeSeries,
    public mspass::utility::ProcessingHistory
 {
 public:

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -2,6 +2,7 @@
 #define _TIMESERIES_H_
 #include "mspass/seismic/CoreTimeSeries.h"
 #include "mspass/utility/ProcessingHistory.h"
+#include "mspass/utility/ErrorLogger.h"
 namespace mspass::seismic{
   /*! \brief Implemntation of TimeSeries for MsPASS.
 

--- a/cxx/include/mspass/utility/ProcessingHistory.h
+++ b/cxx/include/mspass/utility/ProcessingHistory.h
@@ -426,7 +426,7 @@ public:
   */
   void add_many_inputs(const std::vector<ProcessingHistory*>& d);
 
-  /*! \brief Merge the history nodes from another. 
+  /*! \brief Merge the history nodes from another.
 
   \param data_to_add is the ProcessingHistory of the data object to be
     merged.
@@ -707,7 +707,8 @@ private:
       ar & mytype;
       ar & algorithm;
       ar & algid;
-      ar & elog;
+      /* Earlier implementations had elog in ProcessingHistory here. */
+      //ar & elog;
   };
 };
 /* function prototypes of helpers */

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -319,7 +319,7 @@ PYBIND11_MODULE(seismic, m) {
         boost::archive::text_oarchive arcorets(sscorets);
         arcorets<<dynamic_cast<const ProcessingHistory&>(self);
         stringstream sselog;
-	boost::archive::text_oarchive arelog(sselog);
+      	boost::archive::text_oarchive arelog(sselog);
         arelog<<self.elog;
         // these are behind getter/setters
         bool cardinal=self.cardinal();
@@ -333,12 +333,12 @@ PYBIND11_MODULE(seismic, m) {
         size_t u_size = self.u.rows()*self.u.columns();
         if(u_size==0){
           py::array_t<double, py::array::f_style> darr(u_size,NULL);
-          return py::make_tuple(sbuf,ssbts.str(),sscorets.str(),
+          return py::make_tuple(sbuf,ssbts.str(),sselog.str(),sscorets.str(),
             cardinal, orthogonal,sstm.str(),
             u_size, darr);
         } else {
           py::array_t<double, py::array::f_style> darr(u_size,self.u.get_address(0,0));
-          return py::make_tuple(sbuf,ssbts.str(),sscorets.str(),
+          return py::make_tuple(sbuf,ssbts.str(),sselog.str(),sscorets.str(),
             cardinal, orthogonal,sstm.str(),
             u_size, darr);
         }
@@ -352,9 +352,9 @@ PYBIND11_MODULE(seismic, m) {
         BasicTimeSeries bts;
         arbts>>bts;
         stringstream sselog(t[2].cast<std::string>());
-	boost::archive::text_iarchive arelog(sselog);
-	ErrorLogger elog;
-	arelog>>elog;
+        boost::archive::text_iarchive arelog(sselog);
+        ErrorLogger elog;
+        arelog>>elog;
         stringstream sscorets(t[3].cast<std::string>());
         boost::archive::text_iarchive arcorets(sscorets);
         ProcessingHistory corets;
@@ -367,7 +367,7 @@ PYBIND11_MODULE(seismic, m) {
         artm>>tmatrix;
         size_t u_size = t[7].cast<size_t>();
         py::array_t<double, py::array::f_style> darr;
-        darr=t[7].cast<py::array_t<double, py::array::f_style>>();
+        darr=t[8].cast<py::array_t<double, py::array::f_style>>();
         py::buffer_info info = darr.request();
         if(u_size==0) {
           dmatrix u;
@@ -443,16 +443,16 @@ PYBIND11_MODULE(seismic, m) {
           ssbts << std::setprecision(17);
           boost::archive::text_oarchive arbts(ssbts);
           arbts << dynamic_cast<const BasicTimeSeries&>(self);
-	  stringstream sselog;
-	  boost::archive::text_oarchive arelog(sselog);
-	  arelog << self.elog;
+          stringstream sselog;
+          boost::archive::text_oarchive arelog(sselog);
+          arelog << self.elog;
           stringstream sscorets;
           boost::archive::text_oarchive arcorets(sscorets);
           arcorets<<dynamic_cast<const ProcessingHistory&>(self);
           //This creates a numpy array alias from the vector container
           //without a move or copy of the data
           py::array_t<double, py::array::f_style> darr(self.s.size(),&(self.s[0]));
-          return py::make_tuple(sbuf,ssbts.str(),sscorets.str(),darr);
+          return py::make_tuple(sbuf,ssbts.str(),sselog.str(),sscorets.str(),darr);
         },
         [](py::tuple t) {
          string sbuf=t[0].cast<std::string>();
@@ -462,10 +462,10 @@ PYBIND11_MODULE(seismic, m) {
          boost::archive::text_iarchive arbts(ssbts);
          BasicTimeSeries bts;
          arbts>>bts;
-	 stringstream sselog(t[2].cast<std::string>());
-	 boost::archive::text_iarchive arelog(sselog);
-	 ErrorLogger elog;
-	 arelog >> elog;
+         stringstream sselog(t[2].cast<std::string>());
+         boost::archive::text_iarchive arelog(sselog);
+         ErrorLogger elog;
+         arelog >> elog;
          stringstream sscorets(t[3].cast<std::string>());
          boost::archive::text_iarchive arcorets(sscorets);
          ProcessingHistory corets;

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -296,6 +296,8 @@ PYBIND11_MODULE(seismic, m) {
     .def(py::init<>())
     .def(py::init<const Seismogram&>())
     .def(py::init<const CoreSeismogram&>())
+    .def(py::init<const size_t>())
+    .def(py::init<const BasicTimeSeries&,const Metadata&>())
     .def(py::init<const CoreSeismogram&,const std::string>())
     /* Don't think we really want to expose this to python if we don't need to
     .def(py::init<const BasicTimeSeries&,const Metadata&, const CoreSeismogram,
@@ -375,7 +377,9 @@ PYBIND11_MODULE(seismic, m) {
     py::class_<TimeSeries,CoreTimeSeries,ProcessingHistory>(m,"TimeSeries","mspass scalar time series data object")
       .def(py::init<>())
       .def(py::init<const TimeSeries&>())
+      .def(py::init<const size_t>())
       .def(py::init<const CoreTimeSeries&>())
+      .def(py::init<const BasicTimeSeries&,const Metadata&>())
       .def(py::init<const CoreTimeSeries&,const std::string>())
       .def(py::init([](py::dict d, py::array_t<double, py::array::f_style | py::array::forcecast> b) {
         py::buffer_info info = b.request();

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -335,7 +335,7 @@ PYBIND11_MODULE(utility, m) {
     .def("is_defined",&Metadata::is_defined,"Test if a key has a defined value")
     .def("__contains__",&Metadata::is_defined,"Test if a key has a defined value")
     .def("append_chain",&Metadata::append_chain,"Create or append to a string attribute that defines a chain")
-    .def("clear",&Metadata::clear,"Clears contents associated with a key")
+    .def("erase",&Metadata::clear,"Delete contents associated with a single key")
     .def("__delitem__",&Metadata::clear,"Clears contents associated with a key")
     .def("__len__",&Metadata::size,"Return len(self)")
     .def("__iter__", [](py::object s) { return PyMetadataIterator(s.cast<const Metadata &>(), s); })
@@ -861,7 +861,7 @@ PYBIND11_MODULE(utility, m) {
       py::arg("newstatus") = ProcessingStatus::VOLATILE)
     .def("map_as_saved",&ProcessingHistory::map_as_saved,
       "Load data defining this as the end of chain that was or will soon be saved")
-    .def("clear",&ProcessingHistory::clear,
+    .def("clear_history",&ProcessingHistory::clear,
       "Clear this history chain - use with caution")
     .def("get_nodes", &ProcessingHistory::get_nodes,
       "Retrieve the nodes multimap that defines the tree stucture branches")

--- a/cxx/src/lib/algorithms/seismogram_helpers.cc
+++ b/cxx/src/lib/algorithms/seismogram_helpers.cc
@@ -199,8 +199,9 @@ TimeSeries ExtractComponent(const Seismogram& tcs,const unsigned int component)
     }
     TimeSeries result(dynamic_cast<const BasicTimeSeries&>(tcs),
       dynamic_cast<const Metadata&>(tcs),
-        dynamic_cast<const ProcessingHistory&>(tcs),
-          scomp);
+        tcs.elog,
+          dynamic_cast<const ProcessingHistory&>(tcs),
+            scomp);
     /*we hard code some ProcessingHistory here with the algid defining the
     component number extracted.   This model should work for any algorithm that
     has only one argument that can be represented as a string.  We do do

--- a/cxx/src/lib/seismic/CoreTimeSeries.cc
+++ b/cxx/src/lib/seismic/CoreTimeSeries.cc
@@ -18,11 +18,16 @@ CoreTimeSeries::CoreTimeSeries() : BasicTimeSeries(), Metadata()
     this->set_t0(0.0);
     this->set_npts(0);
 }
-CoreTimeSeries::CoreTimeSeries(size_t nsin) : BasicTimeSeries(), Metadata()
+CoreTimeSeries::CoreTimeSeries(const size_t nsin) : BasicTimeSeries(), Metadata()
 {
-  this->set_dt(1.0);
-  this->set_t0(0.0);
-  /* This assumes current api where set_npts allocates and initializes s
+  /* IMPORTANT:  this constructor assumes BasicTimeSeries initializes the
+  equivalent of:
+  set_dt(1.0)
+  set_t0(0.0)
+  set_tref(TimeReferenceType::Relative)
+  this->kill() - i.e. marked dead
+
+  It further assumes current api where set_npts allocates and initializes s
   to nsin zeros */
   this->CoreTimeSeries::set_npts(nsin);
 }

--- a/cxx/src/lib/seismic/Seismogram.cc
+++ b/cxx/src/lib/seismic/Seismogram.cc
@@ -10,8 +10,10 @@ Seismogram::Seismogram(const size_t nsamples)
 {
 /* Note this constructor body needs no content.  Just a wrapper for CoreSeismogram */
 }
+/* For some weird reason we can't call the parallel constructors for
+CoreSeismogram.  Instead we have to call the constructors for the base class.*/
 Seismogram::Seismogram(const CoreSeismogram& d)
-    : CoreSeismogram(d),ProcessingHistory(),elog()
+    : CoreSeismogram(d), ProcessingHistory(),elog()
 {
   /* Note this constructor body needs no content.  Just a wrapper  */
 }
@@ -65,8 +67,10 @@ Seismogram::Seismogram(const BasicTimeSeries& b, const Metadata& m,
   const ErrorLogger& elg,
   const ProcessingHistory& his,const bool card, const bool ortho,
   const dmatrix& tm, const dmatrix& uin)
-     : BasicTimeSeries(b), Metadata(m), ProcessingHistory(his),elog(elg)
+  : ProcessingHistory(his),elog(elg)
 {
+  this->BasicTimeSeries::operator=(b);
+  this->Metadata::operator=(m);
   components_are_cardinal=card;
   components_are_orthogonal=ortho;
   int i,j;

--- a/cxx/src/lib/seismic/Seismogram.cc
+++ b/cxx/src/lib/seismic/Seismogram.cc
@@ -1,6 +1,4 @@
 #include "mspass/seismic/Seismogram.h"
-#include "mspass/utility/ProcessingHistory.h"
-#include "mspass/utility/ErrorLogger.h"
 namespace mspass::seismic
 {
 using namespace std;

--- a/cxx/src/lib/seismic/Seismogram.cc
+++ b/cxx/src/lib/seismic/Seismogram.cc
@@ -4,10 +4,15 @@ namespace mspass::seismic
 {
 using namespace std;
 using namespace mspass::utility;
-
+Seismogram::Seismogram(const size_t nsamples)
+   : CoreSeismogram(nsamples),ProcessingHistory()
+{
+/* Note this constructor body needs no content.  Just a wrapper for CoreSeismogram */
+}
 Seismogram::Seismogram(const CoreSeismogram& d)
     : CoreSeismogram(d),ProcessingHistory()
 {
+  /* Note this constructor body needs no content.  Just a wrapper  */
 }
 Seismogram::Seismogram(const CoreSeismogram& d, const string alg)
     : CoreSeismogram(d),ProcessingHistory()
@@ -19,6 +24,35 @@ Seismogram::Seismogram(const CoreSeismogram& d, const string alg)
   this->ProcessingHistory::set_jobname(string("test"));
   this->ProcessingHistory::set_jobid(string("test"));
 }
+Seismogram::Seismogram(const BasicTimeSeries& bts, const Metadata& md)
+  : CoreSeismogram(md,false),ProcessingHistory()
+{
+  /* the contents of BasicTimeSeries passed will override anything set from
+  Metadata in this section.  Note also the very important use of this
+  for the putters to assure proper resolution of the virtual methods */
+  this->kill();   //set dead because buffer has invalid data
+  this->set_t0(bts.t0());
+  this->set_tref(bts.timetype());
+  this->set_npts(bts.npts());
+  /* The handling of these is kind of awkward in the current api.  Good to
+  hide it here.   Note in current implementation force_t0_shift sets the
+  shift as valid (what shifted tests).  I am slightly worried there are
+  cases where the else block could create an inconsistency with active
+  source data if this method were used to convert raw data.  Careful if
+  this is used in that context where the time reference is defined
+  implicitly as shot time with no tie to an absolute time reference */
+  if(bts.shifted())
+  {
+    double t0shift;
+    t0shift=bts.time_reference();
+    this->force_t0_shift(t0shift);
+  }
+  else
+  {
+    this->force_t0_shift(0.0);
+  }
+}
+
 Seismogram::Seismogram(const BasicTimeSeries& b, const Metadata& m,
   const ProcessingHistory& his,const bool card, const bool ortho,
   const dmatrix& tm, const dmatrix& uin)

--- a/cxx/src/lib/seismic/TimeSeries.cc
+++ b/cxx/src/lib/seismic/TimeSeries.cc
@@ -5,7 +5,7 @@ using namespace std;
 using namespace mspass::utility;
 
 TimeSeries::TimeSeries(const CoreTimeSeries& d, const std::string alg)
-    : CoreTimeSeries(d),ProcessingHistory()
+    : CoreTimeSeries(d),ProcessingHistory(),elog()
 {
   /* Not sure this is a good idea, but will give each instance
   created by this constructor a uuid.*/
@@ -18,8 +18,8 @@ TimeSeries::TimeSeries(const CoreTimeSeries& d, const std::string alg)
 out of the regular order of an object created by inheritance.  I hope
 that does not cause problems. */
 TimeSeries::TimeSeries(const BasicTimeSeries& b, const Metadata& m,
-  const ProcessingHistory& his,const vector<double>& d)
-    : CoreTimeSeries(b,m),ProcessingHistory(his)
+  const ErrorLogger& elg, const ProcessingHistory& his,const vector<double>& d)
+    : BasicTimeSeries(b), Metadata(m), ProcessingHistory(his),elog(elg)
 {
   this->s=d;
 }
@@ -27,6 +27,7 @@ TimeSeries& TimeSeries::operator=(const TimeSeries& parent)
 {
     if(this!=(&parent))
     {
+        this->elog=parent.elog;
         this->CoreTimeSeries::operator=(parent);
         this->ProcessingHistory::operator=(parent);
     }

--- a/cxx/src/lib/seismic/TimeSeries.cc
+++ b/cxx/src/lib/seismic/TimeSeries.cc
@@ -19,8 +19,10 @@ out of the regular order of an object created by inheritance.  I hope
 that does not cause problems. */
 TimeSeries::TimeSeries(const BasicTimeSeries& b, const Metadata& m,
   const ErrorLogger& elg, const ProcessingHistory& his,const vector<double>& d)
-    : BasicTimeSeries(b), Metadata(m), ProcessingHistory(his),elog(elg)
+    : ProcessingHistory(his),elog(elg)
 {
+  this->BasicTimeSeries::operator=(b);
+  this->Metadata::operator=(m);
   this->s=d;
 }
 TimeSeries& TimeSeries::operator=(const TimeSeries& parent)

--- a/cxx/test/tcs/test_tcs.cc
+++ b/cxx/test/tcs/test_tcs.cc
@@ -3,6 +3,7 @@
 //#include <boost/archive/text_oarchive.hpp>
 //#include <boost/archive/text_iarchive.hpp>
 #include "mspass/seismic/CoreSeismogram.h"
+#include "mspass/seismic/Seismogram.h"
 #include "mspass/utility/AntelopePf.h"
 using namespace std;
 using namespace mspass::utility;
@@ -244,7 +245,28 @@ int main(int argc, char **argv)
         cout << "Computed transformation matrix:"<<endl;
         tm=s4.get_transformation_matrix();
         cout << tm<<endl;
-        exit(0);
+	///
+	cout << "Testing Seismogram constructor from CoreSeismogram"<<endl;
+	Seismogram s5(s4);
+	cout << "Transformation matrix - should be same as previous"<<endl;
+	tm = s5.get_transformation_matrix();
+	cout << tm<<endl;
+	if(s5.live())
+		cout << "Result is still marked live"<<endl;
+	else
+	{
+		cout << "Result is marked dead - error"<<endl;
+        	exit(0);
+	}
+	cout << "Testing Seismogram copy constructor"<<endl;
+	Seismogram s6(s5);
+	if(s6.live())
+		cout << "Result is still marked live"<<endl;
+	else
+	{
+		cout << "Result is marked dead - error"<<endl;
+        	exit(0);
+	}
     }
     catch (MsPASSError&  serr)
     {

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -20,8 +20,7 @@ from array import array
 from mspasspy.ccore.seismic import (BasicTimeSeries,
                             TimeSeries,
                             Seismogram,
-                            CoreSeismogram,
-                            CoreTimeSeries,
+                            _CoreSeismogram,
                             TimeReferenceType,
                             TimeSeries,
                             DoubleVector)
@@ -124,7 +123,7 @@ class Database(pymongo.database.Database):
             mspass_object = TimeSeries({k:md[k] for k in md}, np.ndarray([0], dtype=np.float64))
             mspass_object.npts = md['npts']  # fixme
         elif object['dtype'] == 'Seismogram':
-            mspass_object = Seismogram(CoreSeismogram(md, False))
+            mspass_object = Seismogram(_CoreSeismogram(md, False))
         else:
             return None
 
@@ -205,7 +204,7 @@ class Database(pymongo.database.Database):
 
         for k in copied_metadata:
             if not str(copied_metadata[k]).strip():
-                copied_metadata.clear(k)
+                copied_metadata.erase(k)
 
         # skip _id and attributes in other collections
         skip_list = ['_id', 'site_lat', 'site_lon', 'site_elev', 'site_starttime', 'site_endtime', 'source_lat',

--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -5,8 +5,7 @@ import numpy as np
 import obspy.core
 
 from mspasspy.ccore.utility import (ErrorSeverity, Metadata)
-from mspasspy.ccore.seismic import (CoreSeismogram,
-                                    CoreTimeSeries,
+from mspasspy.ccore.seismic import (_CoreSeismogram,
                                     Seismogram,
                                     TimeReferenceType,
                                     TimeSeries,
@@ -374,11 +373,11 @@ def Stream2Seismogram(st, master=0, cardinal=False, azimuth='azimuth', dip='dip'
             vang = bundle[i].get_double(dip)
             bundle[i].put('vang', vang)
     # Assume now bundle contains all the pieces we need.   This constructor
-    # for CoreSeismogram should then do the job
+    # for _CoreSeismogram should then do the job
     # This may throw an exception, but we require the caller to handle it
     # All errors returned by this constructor currenlty leave the data INVALID
     # so handler should discard anything with an error
-    dout = CoreSeismogram(bundle, master)
+    dout = _CoreSeismogram(bundle, master)
     res = Seismogram(dout, 'INVALID')
     res.live = True
     return res

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -10,8 +10,8 @@ import numpy as np
 import pytest
 
 from mspasspy.ccore.seismic import (TimeReferenceType,
-                                    CoreTimeSeries,
-                                    CoreSeismogram,
+                                    _CoreTimeSeries,
+                                    _CoreSeismogram,
                                     TimeSeries,
                                     Seismogram,
                                     TimeSeriesEnsemble, 
@@ -27,7 +27,7 @@ from mspasspy.algorithms.window import scale
 from mspasspy.algorithms.window import WindowData
 
 
-# Build a simple CoreTimeSeries and CoreSeismogram with 
+# Build a simple _CoreTimeSeries and _CoreSeismogram with 
 # 100 points and a small number of spikes that allow checking
 # by a hand calculation
 def setbasics(d, n):
@@ -42,9 +42,9 @@ def setbasics(d, n):
     d.live=True
 
 def test_scale():
-    dts=CoreTimeSeries(9)
+    dts=_CoreTimeSeries(9)
     dir=setbasics(dts,9)
-    d3c=CoreSeismogram(5)
+    d3c=_CoreSeismogram(5)
     setbasics(d3c,5)
     dts.data[0]=3.0
     dts.data[1]=2.0

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -66,7 +66,7 @@ class TestDatabase():
         self.test_ts['extra2'] = 'extra2'  # exclude
         self.test_ts.elog.log_error("alg", str("message"), ErrorSeverity.Informational)
         self.test_ts.elog.log_error("alg", str("message"), ErrorSeverity.Informational)
-        self.test_ts.clear('starttime')
+        self.test_ts.erase('starttime')
         self.test_ts['t0'] = datetime.utcnow().timestamp()
 
         self.test_seis = get_live_seismogram()
@@ -75,7 +75,7 @@ class TestDatabase():
         self.test_seis['extra2'] = 'extra2'  # exclude
         self.test_seis.elog.log_error("alg", str("message"), ErrorSeverity.Informational)
         self.test_seis.elog.log_error("alg", str("message"), ErrorSeverity.Informational)
-        self.test_seis.clear('starttime')
+        self.test_seis.erase('starttime')
         self.test_seis['t0'] = datetime.utcnow().timestamp()
         self.test_seis['tmatrix'] = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
 
@@ -141,7 +141,7 @@ class TestDatabase():
         self.db._read_data_from_dfile(tmp_ts_2)
         assert all(a == b for a, b in zip(tmp_ts.data, tmp_ts_2.data))
 
-        tmp_ts.clear('dir')
+        tmp_ts.erase('dir')
         with pytest.raises(KeyError) as err:
             self.db._read_data_from_dfile(tmp_ts)
             assert err == KeyError("one of the keys: dir, dfile, foff is missing")
@@ -159,7 +159,7 @@ class TestDatabase():
         assert all(a.any() == b.any() for a, b in zip(tmp_seis.data, tmp_seis_2.data))
 
         with pytest.raises(KeyError) as err:
-            tmp_seis_2.clear('npts')
+            tmp_seis_2.erase('npts')
             self.db._read_data_from_gridfs(tmp_seis_2)
             assert err == KeyError("npts is not defined")
 
@@ -185,7 +185,7 @@ class TestDatabase():
         assert not gfsh.exists(id)
 
         with pytest.raises(KeyError) as err:
-            tmp_ts_2.clear('gridfs_id')
+            tmp_ts_2.erase('gridfs_id')
             self.db._read_data_from_gridfs(tmp_ts_2)
             assert err == KeyError("gridfs_id is not defined")
 
@@ -212,7 +212,7 @@ class TestDatabase():
         assert str(nodes) == str(loaded_nodes)
 
         with pytest.raises(KeyError) as err:
-            ts_2.clear('history_id')
+            ts_2.erase('history_id')
             self.db._load_history(ts_2)
             assert err == KeyError("history_id not found")
 
@@ -360,7 +360,7 @@ if __name__ == '__main__':
     pass
     # ts = get_live_timeseries()
     # ts['t0'] = datetime.utcnow()
-    # ts.clear('starttime')
+    # ts.erase('starttime')
     # me = Metadata(ts)
     # print(me)
     # meta = MetadataDefinitions()

--- a/python/tests/db/test_schema.py
+++ b/python/tests/db/test_schema.py
@@ -61,7 +61,7 @@ class TestSchema():
 
     def test_clear_aliases(self):
         ss = Seismogram()
-        ss.clear('starttime')
+        ss.erase('starttime')
         assert not ss.is_defined('starttime')
         ss['t0'] = 0
         self.mdschema.Seismogram.clear_aliases(ss)

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -5,7 +5,7 @@ import pickle
 import numpy as np
 import pytest
 
-from mspasspy.ccore.seismic import (CoreSeismogram,
+from mspasspy.ccore.seismic import (_CoreSeismogram,
                                     Seismogram,
                                     SeismogramEnsemble,
                                     SlownessVector,
@@ -223,7 +223,7 @@ def test_Metadata():
             assert md[i] == md_copy[i]
 
     del md["<class 'numpy.ndarray'>"]
-    md_copy.clear("<class 'numpy.ndarray'>")
+    md_copy.erase("<class 'numpy.ndarray'>")
     assert not "<class 'numpy.ndarray'>" in md
     assert not "<class 'numpy.ndarray'>" in md_copy
     assert md.keys() == md_copy.keys()
@@ -289,7 +289,7 @@ def test_MetadataBase(MetadataBase):
 
     md_copy = MetadataBase(md)
     del md["<class 'numpy.ndarray'>"]
-    md_copy.clear("<class 'numpy.ndarray'>")
+    md_copy.erase("<class 'numpy.ndarray'>")
     assert not "<class 'numpy.ndarray'>" in md
     assert not "<class 'numpy.ndarray'>" in md_copy
     assert md.keys() == md_copy.keys()
@@ -328,26 +328,26 @@ def test_CoreSeismogram():
     md['npts'] = 100
     # test metadata constructor
     md['tmatrix'] = np.random.rand(3,3)
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix']).all()
     md['tmatrix'] = dmatrix(np.random.rand(3,3))
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix']).all()
     md['tmatrix'] = np.random.rand(9)
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix'].reshape(3,3)).all()
     md['tmatrix'] = np.random.rand(1,9)
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix'].reshape(3,3)).all()
     md['tmatrix'] = np.random.rand(9,1)
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix'].reshape(3,3)).all()
     
     md['tmatrix'] = np.random.rand(3,3).tolist()
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert np.isclose(cseis.transformation_matrix, np.array(md['tmatrix']).reshape(3,3)).all()
     md['tmatrix'] = np.random.rand(9).tolist()
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert np.isclose(cseis.transformation_matrix, np.array(md['tmatrix']).reshape(3,3)).all()
 
     # test whether the setter of transformation_matrix updates metadata correctly
@@ -363,37 +363,37 @@ def test_CoreSeismogram():
     # test exceptions
     md['tmatrix'] = np.random.rand(4,2)
     with pytest.raises(MsPASSError, match = "should be a 3x3 matrix"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = dmatrix(np.random.rand(2,4))
     with pytest.raises(MsPASSError, match = "should be a 3x3 matrix"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = 42
     with pytest.raises(MsPASSError, match = "not recognized"):
-        CoreSeismogram(md, False)
-    md.clear('tmatrix')
+        _CoreSeismogram(md, False)
+    md.erase('tmatrix')
     with pytest.raises(MsPASSError, match = "Error trying to extract"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = {4:2}
     with pytest.raises(MsPASSError, match = "type is not recognized"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     
     md['tmatrix'] = np.random.rand(9).tolist()
     md['tmatrix'][3] = 'str'
     with pytest.raises(MsPASSError, match = "should be float"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = np.random.rand(3,4).tolist()
     with pytest.raises(MsPASSError, match = "should be a 3x3 list of list"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = [1,2,3]
     with pytest.raises(MsPASSError, match = "should be a 3x3 list of list"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = np.random.rand(2,2).tolist()
     with pytest.raises(MsPASSError, match = "should be a list of 9 floats or a 3x3 list of list"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = np.random.rand(3,3).tolist()
     md['tmatrix'][1][1] = 'str'
     with pytest.raises(MsPASSError, match = "should be float"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
 
 
 def test_Seismogram():


### PR DESCRIPTION
This is the revision that moves elog from ProcessingHistory to be a member attribute of atomic TimeSeries and Seismogram data objects.  Also makes some api changes for python.  Most notably Core objects now have a leading underscore:  _CoreTimeSeries and _CoreSeismogram.   This should serve as a clear hint to python programmers these should be used only with caution.

There are a few additional features cleaned up in the process. 

1. Constructors are regularized for Seismogram and TimeSeries to eliminate any need for intermediate Core objects in a python code.
2. Learned a trick to use the "virtual public" inheritance clause to clean up copy constructors for Seismogram and TimeSeries.  There may be a tiny increment in performance.  