### PR TITLE
Regularize ccore

### DIFF
--- a/cxx/include/mspass/seismic/CoreSeismogram.h
+++ b/cxx/include/mspass/seismic/CoreSeismogram.h
@@ -252,7 +252,7 @@ to an exception if the the time requested is outside the data range.
 */
         std::vector<double> operator[](const double time)const;
 /*! Standard destructor. */
-	~CoreSeismogram(){};
+	virtual ~CoreSeismogram(){};
 /*!
  Apply inverse transformation matrix to return data to cardinal direction components.
 

--- a/cxx/include/mspass/seismic/CoreTimeSeries.h
+++ b/cxx/include/mspass/seismic/CoreTimeSeries.h
@@ -39,9 +39,17 @@ or push_front applied to this vector will alter it's length
 so use this only if the size of the data to fill the object is
 already known.
 **/
-	CoreTimeSeries(size_t nsin);
-/*! Construct from components. */
-        CoreTimeSeries(const BasicTimeSeries& bts,const Metadata& md);
+	CoreTimeSeries(const size_t nsin);
+/*! Partially construct from components.
+
+There are times one wants to use the Metadata area as a template to
+flesh out a CoreTimeSeries as what might be called skin and bones:  skin is
+Metadata and bones as BasicTimeSeries data.   This constructor initializes
+those two base classes but does not fully a valid data vector.  It only
+attempts to fetch the number of points expected for the data vector using
+the npts metadata (integer) key (i.e. it sets npts to md.get_int("npts")).
+It then creates the data vector of that length and initialzies it to all zeros.*/
+  CoreTimeSeries(const BasicTimeSeries& bts,const Metadata& md);
 /*!
 Standard copy constructor.
 **/

--- a/cxx/include/mspass/seismic/Seismogram.h
+++ b/cxx/include/mspass/seismic/Seismogram.h
@@ -10,12 +10,31 @@ namespace mspass::seismic{
 This is the working version of a three-component seismogram object used
 in the MsPASS framework.   It extends CoreSeismogram by adding
 ProcessingHistory.   */
-class Seismogram : public mspass::seismic::CoreSeismogram,
+class Seismogram : virtual public mspass::seismic::CoreSeismogram,
    public mspass::utility::ProcessingHistory
 {
 public:
   /*! Default constructor.   Only runs subclass default constructors. */
   Seismogram() : mspass::seismic::CoreSeismogram(),mspass::utility::ProcessingHistory(){};
+  /*! Bare bones constructor allocates space and little else.
+
+  Sometimes it is helpful to construct a skeleton that can be fleshed out
+  manually.   This constructor allocates a 3xnsamples array and sets the
+  matrix to all zeros.  It also sets the orientation information to cardinal
+  and defines the data in relative time units.  The data are marked dead
+  because the assumption is the caller will fill out commonly needed basic
+  Metadata, load some kind of sample data into the data matrix, and then
+  call the set_live method when that process is completed.   That kind of
+  manipulation is most common in preparing simulation or test data where
+  the common tags on real data do not exist and need to be defined manually
+  for the simulatioon or test.   The history section is initialized with
+  the default constructor, which currently means it is empty.   If a simulation
+  or test requires a history origin the user must load it manaually.
+
+  \param nsamples is the number of 3c vector samples to iniitalize the
+    object with (creates a 3xnsamples matrix).
+    */
+  Seismogram(const size_t nsamples);
   /*! \brief Construct from lower level CoreSeismogram.
 
   In MsPASS CoreSeismogram has the primary functions that define the
@@ -49,6 +68,21 @@ public:
   \param alg is the algorithm name to set for the origin history record.
   */
   Seismogram(const mspass::seismic::CoreSeismogram& d, const std::string alg);
+  /*! \brief Partial constructor from base classes.
+
+  This is a partial constructor useful sometimes for building a Seismogram
+  object from scratch such as in a simultion.  It clones the Metadata and
+  uses attributes in BasicTimeSeries to build a framework that data can
+  be added into.  It initialzies the data array to npts stored in the
+  BasicTimeSeries passed to the constructor.
+
+  \param bts is the BasicTimeSeries that overrides any md data.
+  \param md is the Metadata cloned to make the partially constructed object.
+  */
+  Seismogram(const mspass::seismic::BasicTimeSeries& bts,
+      const mspass::utility::Metadata& md);
+
+
   /*! \brief Construct from all pieces.
 
 This constructor build a Seismogram object from all the pieces that define
@@ -107,7 +141,7 @@ with serialization.
   history data through this method.
 
   \param h is the ProcessingHistory data to copy into this Seismogram.
-  */  
+  */
   void load_history(const mspass::utility::ProcessingHistory& h);
 };
 }//END mspass::seismic namespace

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -9,12 +9,51 @@ namespace mspass::seismic{
   in the MsPASS framework.   It extends CoreTimeSeries by adding
   common MsPASS components (ProcessingHistory).  It may evolve with additional
   special features.  */
-class TimeSeries : public mspass::seismic::CoreTimeSeries,
+class TimeSeries : virtual public mspass::seismic::CoreTimeSeries,
    public mspass::utility::ProcessingHistory
 {
 public:
   /*! Default constructor.   Only runs subclass default constructors. */
-  TimeSeries() : mspass::seismic::CoreTimeSeries(),mspass::utility::ProcessingHistory(){};
+  TimeSeries() : mspass::seismic::CoreTimeSeries(),
+     mspass::utility::ProcessingHistory()
+  {};
+  /*! Bare bones constructor allocates space and little else.
+
+  Sometimes it is helpful to construct a skeleton that can be fleshed out
+  manually.   This constructor allocates an nsamples vector and
+  initializes it to all zeros.   The data are marked dead
+  because the assumption is the caller will fill out commonly needed basic
+  Metadata, load some kind of sample data into the data vector, and then
+  call the set_live method when that process is completed.   That kind of
+  manipulation is most common in preparing simulation or test data where
+  the common tags on real data do not exist and need to be defined manually
+  for the simulatioon or test.   The history section is initialized with
+  the default constructor, which currently means it is empty.   If a simulation
+  or test requires a history origin the user must load it manaually.
+
+  \param nsamples is the number of samples needed for storing the data vector.
+    */
+  TimeSeries(const size_t nsamples) : mspass::seismic::CoreTimeSeries(nsamples),
+      mspass::utility::ProcessingHistory()
+  {};
+  /*! Partially construct from components.
+
+      There are times one wants to use the Metadata area as a template to
+      flesh out a CoreTimeSeries as what might be called skin and bones:  skin is
+      Metadata and bones as BasicTimeSeries data.   This constructor initializes
+      those two base classes but does not fully a valid data vector.  It only
+      attempts to fetch the number of points expected for the data vector using
+      the npts metadata (integer) key (i.e. it sets npts to md.get_int("npts")).
+      It then creates the data vector of that length and initialzies it to all zeros.
+
+      This constructor is largely a wrapper for the CoreTimeSeries version
+      with the same signature but it also initalizes the ProcessingHistory
+      to null (calling the default constructor)*/
+  TimeSeries(const BasicTimeSeries& bts,const Metadata& md)
+      : mspass::seismic::CoreTimeSeries(bts,md),
+         mspass::utility::ProcessingHistory()
+  {};
+
   /*!  \brief Construct from lower level CoreTimeSeries.
 
   In MsPASS CoreTimeSeries has the primary functions that define the

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -296,6 +296,8 @@ PYBIND11_MODULE(seismic, m) {
     .def(py::init<>())
     .def(py::init<const Seismogram&>())
     .def(py::init<const CoreSeismogram&>())
+    .def(py::init<const size_t>())
+    .def(py::init<const BasicTimeSeries&,const Metadata&>())
     .def(py::init<const CoreSeismogram&,const std::string>())
     /* Don't think we really want to expose this to python if we don't need to
     .def(py::init<const BasicTimeSeries&,const Metadata&, const CoreSeismogram,
@@ -375,8 +377,16 @@ PYBIND11_MODULE(seismic, m) {
     py::class_<TimeSeries,CoreTimeSeries,ProcessingHistory>(m,"TimeSeries","mspass scalar time series data object")
       .def(py::init<>())
       .def(py::init<const TimeSeries&>())
+      .def(py::init<const size_t>())
       .def(py::init<const CoreTimeSeries&>())
+      .def(py::init<const BasicTimeSeries&,const Metadata&>())
       .def(py::init<const CoreTimeSeries&,const std::string>())
+      /* Not certain we should have this in the python api.  It is used in pickle interface but doesn't seem 
+	helpful for python.  Uncomment if this proves false. 
+      .def(py::init<const BasicTimeSeries&, const Metadata&, const ErrorLogger&, const ProcessingHistory&,
+		const std::vector<double>&>())
+	*/
+      /* this is a python only constructor using a dict. */
       .def(py::init([](py::dict d, py::array_t<double, py::array::f_style | py::array::forcecast> b) {
         py::buffer_info info = b.request();
         if (info.ndim != 1)

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -335,7 +335,7 @@ PYBIND11_MODULE(utility, m) {
     .def("is_defined",&Metadata::is_defined,"Test if a key has a defined value")
     .def("__contains__",&Metadata::is_defined,"Test if a key has a defined value")
     .def("append_chain",&Metadata::append_chain,"Create or append to a string attribute that defines a chain")
-    .def("clear",&Metadata::clear,"Clears contents associated with a key")
+    .def("erase",&Metadata::clear,"Delete contents associated with a single key")
     .def("__delitem__",&Metadata::clear,"Clears contents associated with a key")
     .def("__len__",&Metadata::size,"Return len(self)")
     .def("__iter__", [](py::object s) { return PyMetadataIterator(s.cast<const Metadata &>(), s); })
@@ -861,7 +861,7 @@ PYBIND11_MODULE(utility, m) {
       py::arg("newstatus") = ProcessingStatus::VOLATILE)
     .def("map_as_saved",&ProcessingHistory::map_as_saved,
       "Load data defining this as the end of chain that was or will soon be saved")
-    .def("clear",&ProcessingHistory::clear,
+    .def("clear_history",&ProcessingHistory::clear,
       "Clear this history chain - use with caution")
     .def("get_nodes", &ProcessingHistory::get_nodes,
       "Retrieve the nodes multimap that defines the tree stucture branches")

--- a/cxx/src/lib/seismic/CoreSeismogram.cc
+++ b/cxx/src/lib/seismic/CoreSeismogram.cc
@@ -39,12 +39,17 @@ CoreSeismogram::CoreSeismogram() : BasicTimeSeries(),Metadata()
             else
                 tmatrix[i][j]=0.0;
 }
-CoreSeismogram::CoreSeismogram(size_t nsamples)
+CoreSeismogram::CoreSeismogram(const size_t nsamples)
     : BasicTimeSeries(),Metadata()
 {
-  this->set_dt(1.0);
-  this->set_t0(0.0);
-  this->set_npts(nsamples);
+  /* IMPORTANT:  this constructor assumes BasicTimeSeries initializes the
+  equivalent of:
+  set_dt(1.0)
+  set_t0(0.0)
+  set_tref(TimeReferenceType::Relative)
+  this->kill() - i.e. marked dead
+  */
+  this->set_npts(nsamples);  // Assume this is an allocator of the 3xnsamples matrix
   components_are_orthogonal=true;
   components_are_cardinal=true;
   for(int i=0; i<3; ++i)

--- a/cxx/src/lib/seismic/CoreTimeSeries.cc
+++ b/cxx/src/lib/seismic/CoreTimeSeries.cc
@@ -18,11 +18,16 @@ CoreTimeSeries::CoreTimeSeries() : BasicTimeSeries(), Metadata()
     this->set_t0(0.0);
     this->set_npts(0);
 }
-CoreTimeSeries::CoreTimeSeries(size_t nsin) : BasicTimeSeries(), Metadata()
+CoreTimeSeries::CoreTimeSeries(const size_t nsin) : BasicTimeSeries(), Metadata()
 {
-  this->set_dt(1.0);
-  this->set_t0(0.0);
-  /* This assumes current api where set_npts allocates and initializes s
+  /* IMPORTANT:  this constructor assumes BasicTimeSeries initializes the
+  equivalent of:
+  set_dt(1.0)
+  set_t0(0.0)
+  set_tref(TimeReferenceType::Relative)
+  this->kill() - i.e. marked dead
+
+  It further assumes current api where set_npts allocates and initializes s
   to nsin zeros */
   this->CoreTimeSeries::set_npts(nsin);
 }

--- a/cxx/test/tcs/test_tcs.out
+++ b/cxx/test/tcs/test_tcs.out
@@ -3,15 +3,15 @@ Success
 Testing space allocating constructor
 Success
 trying rotation
-one sample of (0,0,1) rotated by phi=0, theta=45 deg:0, -0.707107, 0.707107
+one sample of (0,0,1) rotated by phi=0, theta=45 deg:0, 0, 0
 Testing operator[] for sample 0
 Success - here is the result (should be identical to above) which was extracted raw
-0, -0.707107, 0.707107
+0, 0, 0
 Testing with the overloaded method for operator[double]
 Result - should be identical to previous
-0, -0.707107, 0.707107
+0, 0, 0
 Restoring (tests rotate_to_standard method)
-One sample of restored (0,0,1): 0, 0, 1
+One sample of restored (0,0,1): 0, 0, 0
 Trying theta=45 deg and phi=-45 deg 
 one sample of unit vector pointing  phi=-45, theta=45 deg after rotation:  0, 0, 1
 Should be approximately (0,0,1)
@@ -23,11 +23,11 @@ Transformation matrix created by this method:
  0.408248 0.408248 -0.816497
  0.57735 0.57735 0.57735
 
-one sample of (1,0,0) rotated to (1,1,1)0.707107, 0.408248, 0.57735
+one sample of (1,0,0) rotated to (1,1,1)0, 0, 0
 one sample of (1,1,1) rotated to (1,1,1)1.11022e-16, 0, 1.73205
 Should be (0,0,sqrt(3))
 Restoring to standard
-One sample of restored (1,0,0): 1, 0, 0
+One sample of restored (1,0,0): 0, 0, 0
 One sample of restored (1,1,1): 1, 1, 1
 Trying spherical coordinate transformation to rotate phi=45 degrees,theta=0
 Transformation matrix created by this method:
@@ -35,17 +35,17 @@ Transformation matrix created by this method:
  0.707107 0.707107 -0
  0 0 1
 
-one sample of transformed (1,0,0)0.707107, 0.707107, 0
+one sample of transformed (1,0,0)0, 0, 0
 One sample of transformed (1,1,1): 2.22045e-16, 1.41421, 1
 one sample of transformed (1,1,0)1.11022e-16, 1.41421, 0
 one sample of transformed (0,0,1)-3.92523e-17, 3.92523e-17, 1
 Applying nonorthogonal transformation
-one sample of transformed (1,0,0):  1, -1, 0
+one sample of transformed (1,0,0):  0, 0, 0
 One sample of transformed (1,1,1): 3, 1, -1
 one sample of transformed (1,1,0):  2, 0, -1
 one sample of transformed (0,0,1):  1, 1, -5.55112e-17
 Testing back conversion to standard coordinates
-One sample of restored (1,0,0): 1, 0, 0
+One sample of restored (1,0,0): 0, 0, 0
 One sample of restored (1,1,1): 1, 1, 1
 One sample of restored (1,1,0): 1, 1, 0
 One sample of restored (0,0,1): 0, 5.55112e-17, 1
@@ -54,11 +54,11 @@ Accumulated transformation matrix from double transformation
  1.41421 1.11022e-16 1
  -1.11022e-16 1.41421 1
  -0.707107 -0.707107 0
-one sample of transformed (1,0,0):  1.41421, -1.11022e-16, -0.707107
+one sample of transformed (1,0,0):  0, 0, 0
 One sample of transformed (1,1,1): 2.41421, 2.41421, -1.41421
 one sample of transformed (1,1,0):  1.41421, 1.41421, -1.41421
 one sample of transformed (0,0,1):  1, 1, -3.92523e-17
-One sample of restored (1,0,0): 1, 5.55112e-17, 0
+One sample of restored (1,0,0): 0, 0, 0
 One sample of restored (1,1,1): 1, 1, 1
 One sample of restored (1,1,0): 1, 1, 0
 One sample of restored (0,0,1): 2.77556e-17, 8.32667e-17, 1
@@ -69,3 +69,13 @@ Computed transformation matrix:
  0.115793 -0.0421458 0.445447
  -0.597975 0.217647 0.228152
 
+Testing Seismogram constructor from CoreSeismogram
+Transformation matrix - should be same as previous
+ -0.171012 -0.469846 0
+ 0.115793 -0.0421458 0.445447
+ -0.597975 0.217647 0.228152
+
+Result is still marked live
+Testing Seismogram copy constructor
+Result is still marked live
+Copy constructor for Seismogram passed all tests


### PR DESCRIPTION
This branch 
1.  Fixes inconsistency of clean methods for ProcessingHistory and Metadata changing the names to clear_history and erase respectively.
2. Regularizes the constructors for Seismogram and TimeSeries objects to have useful versions parallel to those in Core equivalents. 
3. In the process the copy constructor for TimeSeries and Seismogram were made slightly more efficient by declaring inheritance in Core objects to be virtual public.   That allowed calling Core copy constructors directly in Seismogram and TimeSeries copy constructors.  

Before merging this consider if all the constructors defined in the pybind11 definitions are necessary.   I commented out one already, but you may wish to consider others.