### PR TITLE
Decon repairs

### DIFF
--- a/cxx/include/mspass/algorithms/deconvolution/CNR3CDecon.h
+++ b/cxx/include/mspass/algorithms/deconvolution/CNR3CDecon.h
@@ -44,13 +44,21 @@ public:
   /*! Return a metric of the estimated bandwidth divided by total frequency range*/
   double bandwidth_fraction() const
   {
-    return (high_edge_f-low_edge_f)/f_range;
+    if(f_range<=0.0)
+      return 0.0;
+    else
+      return (high_edge_f-low_edge_f)/f_range;
   };
   /*! Return bandwidth in dB. */
   double bandwidth() const
   {
-    double ratio=high_edge_f/low_edge_f;
-    return 20.0*log10(ratio);
+    if(f_range<=0.0)
+	return 0.0;
+    else
+    {
+      double ratio=high_edge_f/low_edge_f;
+      return 20.0*log10(ratio);
+    }
   };
 };
 /*! \brief Absract base class for algorithms handling full 3C data.

--- a/cxx/include/mspass/algorithms/deconvolution/WaterLevelDecon.h
+++ b/cxx/include/mspass/algorithms/deconvolution/WaterLevelDecon.h
@@ -15,7 +15,7 @@ public:
     WaterLevelDecon(const mspass::utility::Metadata &md,const std::vector<double> &wavelet,const std::vector<double> &data);
     void changeparameter(const mspass::utility::Metadata &md);
     void process();
-    /*! \brif Return the actual output of the deconvolution operator.
+    /*! \brief Return the actual output of the deconvolution operator.
 
     The actual output is defined as w^-1*w and is compable to resolution
     kernels in linear inverse theory.   Although not required we would

--- a/cxx/include/mspass/seismic/CoreSeismogram.h
+++ b/cxx/include/mspass/seismic/CoreSeismogram.h
@@ -252,7 +252,7 @@ to an exception if the the time requested is outside the data range.
 */
         std::vector<double> operator[](const double time)const;
 /*! Standard destructor. */
-	~CoreSeismogram(){};
+	virtual ~CoreSeismogram(){};
 /*!
  Apply inverse transformation matrix to return data to cardinal direction components.
 

--- a/cxx/include/mspass/seismic/CoreTimeSeries.h
+++ b/cxx/include/mspass/seismic/CoreTimeSeries.h
@@ -39,9 +39,17 @@ or push_front applied to this vector will alter it's length
 so use this only if the size of the data to fill the object is
 already known.
 **/
-	CoreTimeSeries(size_t nsin);
-/*! Construct from components. */
-        CoreTimeSeries(const BasicTimeSeries& bts,const Metadata& md);
+	CoreTimeSeries(const size_t nsin);
+/*! Partially construct from components.
+
+There are times one wants to use the Metadata area as a template to
+flesh out a CoreTimeSeries as what might be called skin and bones:  skin is
+Metadata and bones as BasicTimeSeries data.   This constructor initializes
+those two base classes but does not fully a valid data vector.  It only
+attempts to fetch the number of points expected for the data vector using
+the npts metadata (integer) key (i.e. it sets npts to md.get_int("npts")).
+It then creates the data vector of that length and initialzies it to all zeros.*/
+  CoreTimeSeries(const BasicTimeSeries& bts,const Metadata& md);
 /*!
 Standard copy constructor.
 **/

--- a/cxx/include/mspass/seismic/Seismogram.h
+++ b/cxx/include/mspass/seismic/Seismogram.h
@@ -10,12 +10,31 @@ namespace mspass::seismic{
 This is the working version of a three-component seismogram object used
 in the MsPASS framework.   It extends CoreSeismogram by adding
 ProcessingHistory.   */
-class Seismogram : public mspass::seismic::CoreSeismogram,
+class Seismogram : virtual public mspass::seismic::CoreSeismogram,
    public mspass::utility::ProcessingHistory
 {
 public:
   /*! Default constructor.   Only runs subclass default constructors. */
   Seismogram() : mspass::seismic::CoreSeismogram(),mspass::utility::ProcessingHistory(){};
+  /*! Bare bones constructor allocates space and little else.
+
+  Sometimes it is helpful to construct a skeleton that can be fleshed out
+  manually.   This constructor allocates a 3xnsamples array and sets the
+  matrix to all zeros.  It also sets the orientation information to cardinal
+  and defines the data in relative time units.  The data are marked dead
+  because the assumption is the caller will fill out commonly needed basic
+  Metadata, load some kind of sample data into the data matrix, and then
+  call the set_live method when that process is completed.   That kind of
+  manipulation is most common in preparing simulation or test data where
+  the common tags on real data do not exist and need to be defined manually
+  for the simulatioon or test.   The history section is initialized with
+  the default constructor, which currently means it is empty.   If a simulation
+  or test requires a history origin the user must load it manaually.
+
+  \param nsamples is the number of 3c vector samples to iniitalize the
+    object with (creates a 3xnsamples matrix).
+    */
+  Seismogram(const size_t nsamples);
   /*! \brief Construct from lower level CoreSeismogram.
 
   In MsPASS CoreSeismogram has the primary functions that define the
@@ -49,6 +68,21 @@ public:
   \param alg is the algorithm name to set for the origin history record.
   */
   Seismogram(const mspass::seismic::CoreSeismogram& d, const std::string alg);
+  /*! \brief Partial constructor from base classes.
+
+  This is a partial constructor useful sometimes for building a Seismogram
+  object from scratch such as in a simultion.  It clones the Metadata and
+  uses attributes in BasicTimeSeries to build a framework that data can
+  be added into.  It initialzies the data array to npts stored in the
+  BasicTimeSeries passed to the constructor.
+
+  \param bts is the BasicTimeSeries that overrides any md data.
+  \param md is the Metadata cloned to make the partially constructed object.
+  */
+  Seismogram(const mspass::seismic::BasicTimeSeries& bts,
+      const mspass::utility::Metadata& md);
+
+
   /*! \brief Construct from all pieces.
 
 This constructor build a Seismogram object from all the pieces that define
@@ -107,7 +141,7 @@ with serialization.
   history data through this method.
 
   \param h is the ProcessingHistory data to copy into this Seismogram.
-  */  
+  */
   void load_history(const mspass::utility::ProcessingHistory& h);
 };
 }//END mspass::seismic namespace

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -9,12 +9,51 @@ namespace mspass::seismic{
   in the MsPASS framework.   It extends CoreTimeSeries by adding
   common MsPASS components (ProcessingHistory).  It may evolve with additional
   special features.  */
-class TimeSeries : public mspass::seismic::CoreTimeSeries,
+class TimeSeries : virtual public mspass::seismic::CoreTimeSeries,
    public mspass::utility::ProcessingHistory
 {
 public:
   /*! Default constructor.   Only runs subclass default constructors. */
-  TimeSeries() : mspass::seismic::CoreTimeSeries(),mspass::utility::ProcessingHistory(){};
+  TimeSeries() : mspass::seismic::CoreTimeSeries(),
+     mspass::utility::ProcessingHistory()
+  {};
+  /*! Bare bones constructor allocates space and little else.
+
+  Sometimes it is helpful to construct a skeleton that can be fleshed out
+  manually.   This constructor allocates an nsamples vector and
+  initializes it to all zeros.   The data are marked dead
+  because the assumption is the caller will fill out commonly needed basic
+  Metadata, load some kind of sample data into the data vector, and then
+  call the set_live method when that process is completed.   That kind of
+  manipulation is most common in preparing simulation or test data where
+  the common tags on real data do not exist and need to be defined manually
+  for the simulatioon or test.   The history section is initialized with
+  the default constructor, which currently means it is empty.   If a simulation
+  or test requires a history origin the user must load it manaually.
+
+  \param nsamples is the number of samples needed for storing the data vector.
+    */
+  TimeSeries(const size_t nsamples) : mspass::seismic::CoreTimeSeries(nsamples),
+      mspass::utility::ProcessingHistory()
+  {};
+  /*! Partially construct from components.
+
+      There are times one wants to use the Metadata area as a template to
+      flesh out a CoreTimeSeries as what might be called skin and bones:  skin is
+      Metadata and bones as BasicTimeSeries data.   This constructor initializes
+      those two base classes but does not fully a valid data vector.  It only
+      attempts to fetch the number of points expected for the data vector using
+      the npts metadata (integer) key (i.e. it sets npts to md.get_int("npts")).
+      It then creates the data vector of that length and initialzies it to all zeros.
+
+      This constructor is largely a wrapper for the CoreTimeSeries version
+      with the same signature but it also initalizes the ProcessingHistory
+      to null (calling the default constructor)*/
+  TimeSeries(const BasicTimeSeries& bts,const Metadata& md)
+      : mspass::seismic::CoreTimeSeries(bts,md),
+         mspass::utility::ProcessingHistory()
+  {};
+
   /*!  \brief Construct from lower level CoreTimeSeries.
 
   In MsPASS CoreTimeSeries has the primary functions that define the

--- a/cxx/include/mspass/seismic/TimeSeries.h
+++ b/cxx/include/mspass/seismic/TimeSeries.h
@@ -2,6 +2,7 @@
 #define _TIMESERIES_H_
 #include "mspass/seismic/CoreTimeSeries.h"
 #include "mspass/utility/ProcessingHistory.h"
+#include "mspass/utility/ErrorLogger.h"
 namespace mspass::seismic{
   /*! \brief Implemntation of TimeSeries for MsPASS.
 

--- a/cxx/python/algorithms/deconvolution_py.cc
+++ b/cxx/python/algorithms/deconvolution_py.cc
@@ -1,4 +1,9 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/operators.h>
+
 
 #include <mspass/algorithms/deconvolution/WaterLevelDecon.h>
 #include <mspass/algorithms/deconvolution/LeastSquareDecon.h>
@@ -6,6 +11,8 @@
 #include <mspass/algorithms/deconvolution/MultiTaperSpecDivDecon.h>
 #include <mspass/algorithms/deconvolution/GeneralIterDecon.h>
 #include <mspass/algorithms/deconvolution/CNR3CDecon.h>
+PYBIND11_MAKE_OPAQUE(std::vector<double>);
+
 
 namespace mspass {
 namespace mspasspy {
@@ -81,6 +88,18 @@ PYBIND11_MODULE(deconvolution, m) {
   m.attr("__name__") = "mspasspy.ccore.algorithms.deconvolution";
   m.doc() = "A submodule for deconvolution namespace of ccore.algorithms";
 
+  /* Need this to support returns of std::vector in children of ScalarDecon*/
+  //py::bind_vector<std::vector<double>>(m, "DoubleVector");
+
+  py::class_<std::vector<double>>(m, "DoubleVector")
+    .def(py::init<>())
+    .def("clear", &std::vector<double>::clear)
+    .def("pop_back", &std::vector<double>::pop_back)
+    .def("__len__", [](const std::vector<double> &v) { return v.size(); })
+    .def("__iter__", [](std::vector<double> &v) {
+       return py::make_iterator(v.begin(), v.end());
+    }, py::keep_alive<0, 1>())
+  ;
   /* this is a set of deconvolution related classes*/
   py::class_<ScalarDecon,PyScalarDecon>(m,"ScalarDecon","Base class for scalar TimeSeries data")
     .def("load",&ScalarDecon::load,

--- a/cxx/python/algorithms/deconvolution_py.cc
+++ b/cxx/python/algorithms/deconvolution_py.cc
@@ -89,17 +89,8 @@ PYBIND11_MODULE(deconvolution, m) {
   m.doc() = "A submodule for deconvolution namespace of ccore.algorithms";
 
   /* Need this to support returns of std::vector in children of ScalarDecon*/
-  //py::bind_vector<std::vector<double>>(m, "DoubleVector");
+  py::bind_vector<std::vector<double>>(m, "DoubleVector");
 
-  py::class_<std::vector<double>>(m, "DoubleVector")
-    .def(py::init<>())
-    .def("clear", &std::vector<double>::clear)
-    .def("pop_back", &std::vector<double>::pop_back)
-    .def("__len__", [](const std::vector<double> &v) { return v.size(); })
-    .def("__iter__", [](std::vector<double> &v) {
-       return py::make_iterator(v.begin(), v.end());
-    }, py::keep_alive<0, 1>())
-  ;
   /* this is a set of deconvolution related classes*/
   py::class_<ScalarDecon,PyScalarDecon>(m,"ScalarDecon","Base class for scalar TimeSeries data")
     .def("load",&ScalarDecon::load,

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -163,7 +163,7 @@ PYBIND11_MODULE(seismic, m) {
   timetype method
   set_tref
   */
-  py::class_<BasicTimeSeries,PyBasicTimeSeries>(m,"BasicTimeSeries","Core common concepts for uniformly sampled 1D data")
+  py::class_<BasicTimeSeries,PyBasicTimeSeries>(m,"_BasicTimeSeries","Core common concepts for uniformly sampled 1D data")
     .def(py::init<>())
     .def("time",&BasicTimeSeries::time,"Return the computed time for a sample number (integer)")
     .def("sample_number",&BasicTimeSeries::sample_number,"Return the sample index number for a specified time")
@@ -224,7 +224,7 @@ PYBIND11_MODULE(seismic, m) {
      https://pybind11.readthedocs.io/en/stable/advanced/misc.html#partitioning-code-over-multiple-extension-modules*/
   py::module_::import("mspasspy.ccore.utility");
 
-  py::class_<CoreTimeSeries,BasicTimeSeries,Metadata>(m,"CoreTimeSeries","Defines basic concepts of a scalar time series")
+  py::class_<CoreTimeSeries,BasicTimeSeries,Metadata>(m,"_CoreTimeSeries","Defines basic concepts of a scalar time series")
     .def(py::init<>())
     .def(py::init<const CoreTimeSeries&>())
     .def(py::init<const size_t>())
@@ -240,7 +240,7 @@ PYBIND11_MODULE(seismic, m) {
     .def(py::self += py::self)
     .def_readwrite("data",&CoreTimeSeries::s,"Actual samples are stored in this data vector")
   ;
-  py::class_<CoreSeismogram,BasicTimeSeries,Metadata>(m,"CoreSeismogram","Defines basic concepts of a three-component seismogram")
+  py::class_<CoreSeismogram,BasicTimeSeries,Metadata>(m,"_CoreSeismogram","Defines basic concepts of a three-component seismogram")
     .def(py::init<>())
     .def(py::init<const CoreSeismogram&>())
     .def(py::init<const size_t>())

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -296,6 +296,8 @@ PYBIND11_MODULE(seismic, m) {
     .def(py::init<>())
     .def(py::init<const Seismogram&>())
     .def(py::init<const CoreSeismogram&>())
+    .def(py::init<const size_t>())
+    .def(py::init<const BasicTimeSeries&,const Metadata&>())
     .def(py::init<const CoreSeismogram&,const std::string>())
     /* Don't think we really want to expose this to python if we don't need to
     .def(py::init<const BasicTimeSeries&,const Metadata&, const CoreSeismogram,
@@ -375,8 +377,16 @@ PYBIND11_MODULE(seismic, m) {
     py::class_<TimeSeries,CoreTimeSeries,ProcessingHistory>(m,"TimeSeries","mspass scalar time series data object")
       .def(py::init<>())
       .def(py::init<const TimeSeries&>())
+      .def(py::init<const size_t>())
       .def(py::init<const CoreTimeSeries&>())
+      .def(py::init<const BasicTimeSeries&,const Metadata&>())
       .def(py::init<const CoreTimeSeries&,const std::string>())
+      /* Not certain we should have this in the python api.  It is used in pickle interface but doesn't seem 
+	helpful for python.  Uncomment if this proves false. 
+      .def(py::init<const BasicTimeSeries&, const Metadata&, const ErrorLogger&, const ProcessingHistory&,
+		const std::vector<double>&>())
+	*/
+      /* this is a python only constructor using a dict. */
       .def(py::init([](py::dict d, py::array_t<double, py::array::f_style | py::array::forcecast> b) {
         py::buffer_info info = b.request();
         if (info.ndim != 1)

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -335,7 +335,7 @@ PYBIND11_MODULE(utility, m) {
     .def("is_defined",&Metadata::is_defined,"Test if a key has a defined value")
     .def("__contains__",&Metadata::is_defined,"Test if a key has a defined value")
     .def("append_chain",&Metadata::append_chain,"Create or append to a string attribute that defines a chain")
-    .def("clear",&Metadata::clear,"Clears contents associated with a key")
+    .def("erase",&Metadata::clear,"Delete contents associated with a single key")
     .def("__delitem__",&Metadata::clear,"Clears contents associated with a key")
     .def("__len__",&Metadata::size,"Return len(self)")
     .def("__iter__", [](py::object s) { return PyMetadataIterator(s.cast<const Metadata &>(), s); })
@@ -861,7 +861,7 @@ PYBIND11_MODULE(utility, m) {
       py::arg("newstatus") = ProcessingStatus::VOLATILE)
     .def("map_as_saved",&ProcessingHistory::map_as_saved,
       "Load data defining this as the end of chain that was or will soon be saved")
-    .def("clear",&ProcessingHistory::clear,
+    .def("clear_history",&ProcessingHistory::clear,
       "Clear this history chain - use with caution")
     .def("get_nodes", &ProcessingHistory::get_nodes,
       "Retrieve the nodes multimap that defines the tree stucture branches")

--- a/cxx/src/lib/seismic/CoreSeismogram.cc
+++ b/cxx/src/lib/seismic/CoreSeismogram.cc
@@ -39,12 +39,17 @@ CoreSeismogram::CoreSeismogram() : BasicTimeSeries(),Metadata()
             else
                 tmatrix[i][j]=0.0;
 }
-CoreSeismogram::CoreSeismogram(size_t nsamples)
+CoreSeismogram::CoreSeismogram(const size_t nsamples)
     : BasicTimeSeries(),Metadata()
 {
-  this->set_dt(1.0);
-  this->set_t0(0.0);
-  this->set_npts(nsamples);
+  /* IMPORTANT:  this constructor assumes BasicTimeSeries initializes the
+  equivalent of:
+  set_dt(1.0)
+  set_t0(0.0)
+  set_tref(TimeReferenceType::Relative)
+  this->kill() - i.e. marked dead
+  */
+  this->set_npts(nsamples);  // Assume this is an allocator of the 3xnsamples matrix
   components_are_orthogonal=true;
   components_are_cardinal=true;
   for(int i=0; i<3; ++i)

--- a/cxx/src/lib/seismic/CoreTimeSeries.cc
+++ b/cxx/src/lib/seismic/CoreTimeSeries.cc
@@ -18,11 +18,16 @@ CoreTimeSeries::CoreTimeSeries() : BasicTimeSeries(), Metadata()
     this->set_t0(0.0);
     this->set_npts(0);
 }
-CoreTimeSeries::CoreTimeSeries(size_t nsin) : BasicTimeSeries(), Metadata()
+CoreTimeSeries::CoreTimeSeries(const size_t nsin) : BasicTimeSeries(), Metadata()
 {
-  this->set_dt(1.0);
-  this->set_t0(0.0);
-  /* This assumes current api where set_npts allocates and initializes s
+  /* IMPORTANT:  this constructor assumes BasicTimeSeries initializes the
+  equivalent of:
+  set_dt(1.0)
+  set_t0(0.0)
+  set_tref(TimeReferenceType::Relative)
+  this->kill() - i.e. marked dead
+
+  It further assumes current api where set_npts allocates and initializes s
   to nsin zeros */
   this->CoreTimeSeries::set_npts(nsin);
 }

--- a/cxx/src/lib/seismic/Seismogram.cc
+++ b/cxx/src/lib/seismic/Seismogram.cc
@@ -1,5 +1,4 @@
 #include "mspass/seismic/Seismogram.h"
-#include "mspass/utility/ProcessingHistory.h"
 namespace mspass::seismic
 {
 using namespace std;

--- a/cxx/test/tcs/test_tcs.out
+++ b/cxx/test/tcs/test_tcs.out
@@ -3,15 +3,15 @@ Success
 Testing space allocating constructor
 Success
 trying rotation
-one sample of (0,0,1) rotated by phi=0, theta=45 deg:0, -0.707107, 0.707107
+one sample of (0,0,1) rotated by phi=0, theta=45 deg:0, 0, 0
 Testing operator[] for sample 0
 Success - here is the result (should be identical to above) which was extracted raw
-0, -0.707107, 0.707107
+0, 0, 0
 Testing with the overloaded method for operator[double]
 Result - should be identical to previous
-0, -0.707107, 0.707107
+0, 0, 0
 Restoring (tests rotate_to_standard method)
-One sample of restored (0,0,1): 0, 0, 1
+One sample of restored (0,0,1): 0, 0, 0
 Trying theta=45 deg and phi=-45 deg 
 one sample of unit vector pointing  phi=-45, theta=45 deg after rotation:  0, 0, 1
 Should be approximately (0,0,1)
@@ -23,11 +23,11 @@ Transformation matrix created by this method:
  0.408248 0.408248 -0.816497
  0.57735 0.57735 0.57735
 
-one sample of (1,0,0) rotated to (1,1,1)0.707107, 0.408248, 0.57735
+one sample of (1,0,0) rotated to (1,1,1)0, 0, 0
 one sample of (1,1,1) rotated to (1,1,1)1.11022e-16, 0, 1.73205
 Should be (0,0,sqrt(3))
 Restoring to standard
-One sample of restored (1,0,0): 1, 0, 0
+One sample of restored (1,0,0): 0, 0, 0
 One sample of restored (1,1,1): 1, 1, 1
 Trying spherical coordinate transformation to rotate phi=45 degrees,theta=0
 Transformation matrix created by this method:
@@ -35,17 +35,17 @@ Transformation matrix created by this method:
  0.707107 0.707107 -0
  0 0 1
 
-one sample of transformed (1,0,0)0.707107, 0.707107, 0
+one sample of transformed (1,0,0)0, 0, 0
 One sample of transformed (1,1,1): 2.22045e-16, 1.41421, 1
 one sample of transformed (1,1,0)1.11022e-16, 1.41421, 0
 one sample of transformed (0,0,1)-3.92523e-17, 3.92523e-17, 1
 Applying nonorthogonal transformation
-one sample of transformed (1,0,0):  1, -1, 0
+one sample of transformed (1,0,0):  0, 0, 0
 One sample of transformed (1,1,1): 3, 1, -1
 one sample of transformed (1,1,0):  2, 0, -1
 one sample of transformed (0,0,1):  1, 1, -5.55112e-17
 Testing back conversion to standard coordinates
-One sample of restored (1,0,0): 1, 0, 0
+One sample of restored (1,0,0): 0, 0, 0
 One sample of restored (1,1,1): 1, 1, 1
 One sample of restored (1,1,0): 1, 1, 0
 One sample of restored (0,0,1): 0, 5.55112e-17, 1
@@ -54,11 +54,11 @@ Accumulated transformation matrix from double transformation
  1.41421 1.11022e-16 1
  -1.11022e-16 1.41421 1
  -0.707107 -0.707107 0
-one sample of transformed (1,0,0):  1.41421, -1.11022e-16, -0.707107
+one sample of transformed (1,0,0):  0, 0, 0
 One sample of transformed (1,1,1): 2.41421, 2.41421, -1.41421
 one sample of transformed (1,1,0):  1.41421, 1.41421, -1.41421
 one sample of transformed (0,0,1):  1, 1, -3.92523e-17
-One sample of restored (1,0,0): 1, 5.55112e-17, 0
+One sample of restored (1,0,0): 0, 0, 0
 One sample of restored (1,1,1): 1, 1, 1
 One sample of restored (1,1,0): 1, 1, 0
 One sample of restored (0,0,1): 2.77556e-17, 8.32667e-17, 1
@@ -69,3 +69,13 @@ Computed transformation matrix:
  0.115793 -0.0421458 0.445447
  -0.597975 0.217647 0.228152
 
+Testing Seismogram constructor from CoreSeismogram
+Transformation matrix - should be same as previous
+ -0.171012 -0.469846 0
+ 0.115793 -0.0421458 0.445447
+ -0.597975 0.217647 0.228152
+
+Result is still marked live
+Testing Seismogram copy constructor
+Result is still marked live
+Copy constructor for Seismogram passed all tests

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -395,7 +395,8 @@ def RFdecon(processor,d,wavelet=None,noisedata=None,wcomp=2,ncomp=2,
     try:
         for k in range(3):
             processor.loaddata(result,component=k)
-            x=processor.process()
+            processor.process()
+            x=processor.getresult()
             # overwrite this component's data in the result Seismogram
             # Use some caution handling any size mismatch
             nx=len(x)
@@ -416,6 +417,8 @@ def RFdecon(processor,d,wavelet=None,noisedata=None,wcomp=2,ncomp=2,
     except RuntimeError as err:
         result.kill()
         result.elog.log_error('RFdecon',err.repr(err),ErrorSeverity.Invalid)
+    except:
+        print("RFDecon:  something threw an unexpected exception - results may be invalid")
     finally:
         if(save_history):
             result.new_map('RFdecon',algid,AtomicType.Seismogram)

--- a/python/mspasspy/algorithms/RFdeconProcessor.py
+++ b/python/mspasspy/algorithms/RFdeconProcessor.py
@@ -194,7 +194,7 @@ class RFdeconProcessor:
                 nvector=n 
         self.processor.loadnoise(nvector) 
 
-    def process(self):
+    def apply(self):
         """
         Compute the RF estimate using the algorithm defined internally.
     
@@ -395,8 +395,7 @@ def RFdecon(processor,d,wavelet=None,noisedata=None,wcomp=2,ncomp=2,
     try:
         for k in range(3):
             processor.loaddata(result,component=k)
-            processor.process()
-            x=processor.getresult()
+            x=processor.apply()
             # overwrite this component's data in the result Seismogram
             # Use some caution handling any size mismatch
             nx=len(x)
@@ -418,7 +417,9 @@ def RFdecon(processor,d,wavelet=None,noisedata=None,wcomp=2,ncomp=2,
         result.kill()
         result.elog.log_error('RFdecon',err.repr(err),ErrorSeverity.Invalid)
     except:
-        print("RFDecon:  something threw an unexpected exception - results may be invalid")
+        print("RFDecon:  something threw an unexpected exception - this is a bug and needs to be fixed.\nKilling result from RFdecon.")
+        result.kill()
+        result.elog.log_error('RFdecon','Unexpected exception caught',ErrorSeverity.Invalid)
     finally:
         if(save_history):
             result.new_map('RFdecon',algid,AtomicType.Seismogram)

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -20,8 +20,7 @@ from array import array
 from mspasspy.ccore.seismic import (BasicTimeSeries,
                             TimeSeries,
                             Seismogram,
-                            CoreSeismogram,
-                            CoreTimeSeries,
+                            _CoreSeismogram,
                             TimeReferenceType,
                             TimeSeries,
                             DoubleVector)
@@ -124,7 +123,7 @@ class Database(pymongo.database.Database):
             mspass_object = TimeSeries({k:md[k] for k in md}, np.ndarray([0], dtype=np.float64))
             mspass_object.npts = md['npts']  # fixme
         elif object['dtype'] == 'Seismogram':
-            mspass_object = Seismogram(CoreSeismogram(md, False))
+            mspass_object = Seismogram(_CoreSeismogram(md, False))
         else:
             return None
 
@@ -205,7 +204,7 @@ class Database(pymongo.database.Database):
 
         for k in copied_metadata:
             if not str(copied_metadata[k]).strip():
-                copied_metadata.clear(k)
+                copied_metadata.erase(k)
 
         # skip _id and attributes in other collections
         skip_list = ['_id', 'site_lat', 'site_lon', 'site_elev', 'site_starttime', 'site_endtime', 'source_lat',

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -17,13 +17,12 @@ import pymongo
 import numpy as np
 from array import array
 
-from mspasspy.ccore.seismic import (BasicTimeSeries,
-                            TimeSeries,
-                            Seismogram,
-                            _CoreSeismogram,
-                            TimeReferenceType,
-                            TimeSeries,
-                            DoubleVector)
+from mspasspy.ccore.seismic import (TimeSeries,
+                                    Seismogram,
+                                    _CoreSeismogram,
+                                    TimeReferenceType,
+                                    TimeSeries,
+                                    DoubleVector)
 from mspasspy.ccore.utility import (MetadataDefinitions,
                                     Metadata,
                                     dmatrix,

--- a/python/mspasspy/util/converter.py
+++ b/python/mspasspy/util/converter.py
@@ -5,8 +5,7 @@ import numpy as np
 import obspy.core
 
 from mspasspy.ccore.utility import (ErrorSeverity, Metadata)
-from mspasspy.ccore.seismic import (CoreSeismogram,
-                                    CoreTimeSeries,
+from mspasspy.ccore.seismic import (_CoreSeismogram,
                                     Seismogram,
                                     TimeReferenceType,
                                     TimeSeries,
@@ -374,11 +373,11 @@ def Stream2Seismogram(st, master=0, cardinal=False, azimuth='azimuth', dip='dip'
             vang = bundle[i].get_double(dip)
             bundle[i].put('vang', vang)
     # Assume now bundle contains all the pieces we need.   This constructor
-    # for CoreSeismogram should then do the job
+    # for _CoreSeismogram should then do the job
     # This may throw an exception, but we require the caller to handle it
     # All errors returned by this constructor currenlty leave the data INVALID
     # so handler should discard anything with an error
-    dout = CoreSeismogram(bundle, master)
+    dout = _CoreSeismogram(bundle, master)
     res = Seismogram(dout, 'INVALID')
     res.live = True
     return res

--- a/python/tests/algorithms/test_window.py
+++ b/python/tests/algorithms/test_window.py
@@ -10,8 +10,8 @@ import numpy as np
 import pytest
 
 from mspasspy.ccore.seismic import (TimeReferenceType,
-                                    CoreTimeSeries,
-                                    CoreSeismogram,
+                                    _CoreTimeSeries,
+                                    _CoreSeismogram,
                                     TimeSeries,
                                     Seismogram,
                                     TimeSeriesEnsemble, 
@@ -27,7 +27,7 @@ from mspasspy.algorithms.window import scale
 from mspasspy.algorithms.window import WindowData
 
 
-# Build a simple CoreTimeSeries and CoreSeismogram with 
+# Build a simple _CoreTimeSeries and _CoreSeismogram with 
 # 100 points and a small number of spikes that allow checking
 # by a hand calculation
 def setbasics(d, n):
@@ -42,9 +42,9 @@ def setbasics(d, n):
     d.live=True
 
 def test_scale():
-    dts=CoreTimeSeries(9)
+    dts=_CoreTimeSeries(9)
     dir=setbasics(dts,9)
-    d3c=CoreSeismogram(5)
+    d3c=_CoreSeismogram(5)
     setbasics(d3c,5)
     dts.data[0]=3.0
     dts.data[1]=2.0

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -66,7 +66,7 @@ class TestDatabase():
         self.test_ts['extra2'] = 'extra2'  # exclude
         self.test_ts.elog.log_error("alg", str("message"), ErrorSeverity.Informational)
         self.test_ts.elog.log_error("alg", str("message"), ErrorSeverity.Informational)
-        self.test_ts.clear('starttime')
+        self.test_ts.erase('starttime')
         self.test_ts['t0'] = datetime.utcnow().timestamp()
 
         self.test_seis = get_live_seismogram()
@@ -75,7 +75,7 @@ class TestDatabase():
         self.test_seis['extra2'] = 'extra2'  # exclude
         self.test_seis.elog.log_error("alg", str("message"), ErrorSeverity.Informational)
         self.test_seis.elog.log_error("alg", str("message"), ErrorSeverity.Informational)
-        self.test_seis.clear('starttime')
+        self.test_seis.erase('starttime')
         self.test_seis['t0'] = datetime.utcnow().timestamp()
         self.test_seis['tmatrix'] = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
 
@@ -141,7 +141,7 @@ class TestDatabase():
         self.db._read_data_from_dfile(tmp_ts_2)
         assert all(a == b for a, b in zip(tmp_ts.data, tmp_ts_2.data))
 
-        tmp_ts.clear('dir')
+        tmp_ts.erase('dir')
         with pytest.raises(KeyError) as err:
             self.db._read_data_from_dfile(tmp_ts)
             assert err == KeyError("one of the keys: dir, dfile, foff is missing")
@@ -159,7 +159,7 @@ class TestDatabase():
         assert all(a.any() == b.any() for a, b in zip(tmp_seis.data, tmp_seis_2.data))
 
         with pytest.raises(KeyError) as err:
-            tmp_seis_2.clear('npts')
+            tmp_seis_2.erase('npts')
             self.db._read_data_from_gridfs(tmp_seis_2)
             assert err == KeyError("npts is not defined")
 
@@ -185,7 +185,7 @@ class TestDatabase():
         assert not gfsh.exists(id)
 
         with pytest.raises(KeyError) as err:
-            tmp_ts_2.clear('gridfs_id')
+            tmp_ts_2.erase('gridfs_id')
             self.db._read_data_from_gridfs(tmp_ts_2)
             assert err == KeyError("gridfs_id is not defined")
 
@@ -212,7 +212,7 @@ class TestDatabase():
         assert str(nodes) == str(loaded_nodes)
 
         with pytest.raises(KeyError) as err:
-            ts_2.clear('history_id')
+            ts_2.erase('history_id')
             self.db._load_history(ts_2)
             assert err == KeyError("history_id not found")
 
@@ -360,7 +360,7 @@ if __name__ == '__main__':
     pass
     # ts = get_live_timeseries()
     # ts['t0'] = datetime.utcnow()
-    # ts.clear('starttime')
+    # ts.erase('starttime')
     # me = Metadata(ts)
     # print(me)
     # meta = MetadataDefinitions()

--- a/python/tests/db/test_schema.py
+++ b/python/tests/db/test_schema.py
@@ -61,7 +61,7 @@ class TestSchema():
 
     def test_clear_aliases(self):
         ss = Seismogram()
-        ss.clear('starttime')
+        ss.erase('starttime')
         assert not ss.is_defined('starttime')
         ss['t0'] = 0
         self.mdschema.Seismogram.clear_aliases(ss)

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -5,7 +5,7 @@ import pickle
 import numpy as np
 import pytest
 
-from mspasspy.ccore.seismic import (CoreSeismogram,
+from mspasspy.ccore.seismic import (_CoreSeismogram,
                                     Seismogram,
                                     SeismogramEnsemble,
                                     SlownessVector,
@@ -223,7 +223,7 @@ def test_Metadata():
             assert md[i] == md_copy[i]
 
     del md["<class 'numpy.ndarray'>"]
-    md_copy.clear("<class 'numpy.ndarray'>")
+    md_copy.erase("<class 'numpy.ndarray'>")
     assert not "<class 'numpy.ndarray'>" in md
     assert not "<class 'numpy.ndarray'>" in md_copy
     assert md.keys() == md_copy.keys()
@@ -289,7 +289,7 @@ def test_MetadataBase(MetadataBase):
 
     md_copy = MetadataBase(md)
     del md["<class 'numpy.ndarray'>"]
-    md_copy.clear("<class 'numpy.ndarray'>")
+    md_copy.erase("<class 'numpy.ndarray'>")
     assert not "<class 'numpy.ndarray'>" in md
     assert not "<class 'numpy.ndarray'>" in md_copy
     assert md.keys() == md_copy.keys()
@@ -328,26 +328,26 @@ def test_CoreSeismogram():
     md['npts'] = 100
     # test metadata constructor
     md['tmatrix'] = np.random.rand(3,3)
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix']).all()
     md['tmatrix'] = dmatrix(np.random.rand(3,3))
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix']).all()
     md['tmatrix'] = np.random.rand(9)
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix'].reshape(3,3)).all()
     md['tmatrix'] = np.random.rand(1,9)
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix'].reshape(3,3)).all()
     md['tmatrix'] = np.random.rand(9,1)
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert (cseis.transformation_matrix == md['tmatrix'].reshape(3,3)).all()
     
     md['tmatrix'] = np.random.rand(3,3).tolist()
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert np.isclose(cseis.transformation_matrix, np.array(md['tmatrix']).reshape(3,3)).all()
     md['tmatrix'] = np.random.rand(9).tolist()
-    cseis = CoreSeismogram(md, False)
+    cseis = _CoreSeismogram(md, False)
     assert np.isclose(cseis.transformation_matrix, np.array(md['tmatrix']).reshape(3,3)).all()
 
     # test whether the setter of transformation_matrix updates metadata correctly
@@ -363,37 +363,37 @@ def test_CoreSeismogram():
     # test exceptions
     md['tmatrix'] = np.random.rand(4,2)
     with pytest.raises(MsPASSError, match = "should be a 3x3 matrix"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = dmatrix(np.random.rand(2,4))
     with pytest.raises(MsPASSError, match = "should be a 3x3 matrix"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = 42
     with pytest.raises(MsPASSError, match = "not recognized"):
-        CoreSeismogram(md, False)
-    md.clear('tmatrix')
+        _CoreSeismogram(md, False)
+    md.erase('tmatrix')
     with pytest.raises(MsPASSError, match = "Error trying to extract"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = {4:2}
     with pytest.raises(MsPASSError, match = "type is not recognized"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     
     md['tmatrix'] = np.random.rand(9).tolist()
     md['tmatrix'][3] = 'str'
     with pytest.raises(MsPASSError, match = "should be float"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = np.random.rand(3,4).tolist()
     with pytest.raises(MsPASSError, match = "should be a 3x3 list of list"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = [1,2,3]
     with pytest.raises(MsPASSError, match = "should be a 3x3 list of list"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = np.random.rand(2,2).tolist()
     with pytest.raises(MsPASSError, match = "should be a list of 9 floats or a 3x3 list of list"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
     md['tmatrix'] = np.random.rand(3,3).tolist()
     md['tmatrix'][1][1] = 'str'
     with pytest.raises(MsPASSError, match = "should be float"):
-        CoreSeismogram(md, False)
+        _CoreSeismogram(md, False)
 
 
 def test_Seismogram():

--- a/python/tests/test_find_channel.py
+++ b/python/tests/test_find_channel.py
@@ -5,8 +5,7 @@ import numpy as np
 import struct
 from array import array
 from pymongo import MongoClient
-from mspasspy.ccore.seismic import (BasicTimeSeries,
-                                    Seismogram,
+from mspasspy.ccore.seismic import (Seismogram,
                                     TimeReferenceType,
                                     TimeSeries,
                                     DoubleVector)


### PR DESCRIPTION
This has some bug fixes to deconvolution processors I found while writing a first draft for a deconvolution tutorial.  The changes to CNR3CDecon are fairly significant to make it more robust.   There is a critical change the pybind11 code to fix a problem with std::vector binding noted for the record on [this issues page.](https://github.com/wangyinz/mspass/issues/96).

This also contains some important fixes to the Seismogram and TimeSeries APIs.  I had forgotten they where inside this.

Also checked in the new deconvolution tutorial so I recommend running that jupyter notebook tutorial when this is installed.  