### PR TITLE
fix history object id type && testing

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -545,7 +545,11 @@ class Database(pymongo.database.Database):
             history_col.insert_one({'_id': current_uuid, 'nodesdata': history_binary})
         else:
             # new insertion
-            history_col.insert_one({'_id': current_uuid, 'nodesdata': history_binary})
+            try:
+                history_col.insert_one({'_id': current_uuid, 'nodesdata': history_binary})
+            except Exception as e:
+                raise MsPASSError("Failed to save the history object as a new insertion", e)
+
         return current_uuid
 
     def _load_history(self, mspass_object, history_object_id, collection=None):

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -539,16 +539,16 @@ class Database(pymongo.database.Database):
         current_uuid = proc_history.id() # uuid in the current node
         history_binary = pickle.dumps(proc_history)
         # todo save jobname jobid when global history module is done
-        if prev_history_object_id:
-            # overwrite history
-            history_col.delete_one({'_id': prev_history_object_id})
-            history_col.insert_one({'_id': current_uuid, 'nodesdata': history_binary})
-        else:
-            # new insertion
-            try:
+        try:
+            if prev_history_object_id:
+                # overwrite history
+                history_col.delete_one({'_id': prev_history_object_id})
                 history_col.insert_one({'_id': current_uuid, 'nodesdata': history_binary})
-            except Exception as e:
-                raise MsPASSError("Failed to save the history object as a new insertion", e)
+            else:
+                # new insertion
+                history_col.insert_one({'_id': current_uuid, 'nodesdata': history_binary})
+        except pymongo.errors.DuplicateKeyError as e:
+            raise MsPASSError("The history object to be saved has a duplicate uuid", "Fatal") from e
 
         return current_uuid
 

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -170,7 +170,7 @@ class TestDatabase():
         nodes = ts.get_nodes()
         assert str(nodes) == str(loaded_nodes)
 
-        with pytest.raises(MsPASSError, match="Failed to save the history object as a new insertion"):
+        with pytest.raises(MsPASSError, match="The history object to be saved has a duplicate uuid"):
             self.db._save_history(ts)
 
     def test_update_metadata(self):

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -157,8 +157,22 @@ class TestDatabase():
         loaded_nodes = ts_2.get_nodes()
         assert str(nodes) == str(loaded_nodes)
 
+        logging_helper.info(ts, 'dummy_func_3', '3')
+        new_history_object_id = self.db._save_history(ts, history_object_id)
+        res = self.db['history_object'].find_one({'_id': history_object_id})
+        assert not res
+        res = self.db['history_object'].find_one({'_id': new_history_object_id})
+        assert res
+
+        ts_2 = TimeSeries()
+        self.db._load_history(ts_2, new_history_object_id)
+        loaded_nodes = ts_2.get_nodes()
+        nodes = ts.get_nodes()
+        assert str(nodes) == str(loaded_nodes)
+
     def test_update_metadata(self):
         ts = copy.deepcopy(self.test_ts)
+        logging_helper.info(ts, 'deepcopy', '1')
         exclude = ['extra2']
         self.db.update_metadata(ts, update_all=True, exclude=exclude)
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
@@ -198,6 +212,8 @@ class TestDatabase():
         assert not seis2
 
         seis = copy.deepcopy(self.test_seis)
+        logging_helper.info(seis, 'deepcopy', '1')
+
         self.db.save_data(seis, storage_mode='gridfs', update_all=True, exclude=['extra2'])
         seis2 = self.db.read_data(seis['_id'], 'Seismogram')
 
@@ -229,6 +245,7 @@ class TestDatabase():
         assert seis2['source_magnitude'] == res['magnitude']
 
         ts = copy.deepcopy(self.test_ts)
+        logging_helper.info(ts, 'deepcopy', '1')
         self.db.save_data(ts, storage_mode='gridfs', update_all=True, exclude=['extra2'])
         ts2 = self.db.read_data(ts['_id'], 'TimeSeries')
         for key in wf_keys:
@@ -296,6 +313,7 @@ class TestDatabase():
         assert not res
 
         ts = copy.deepcopy(self.test_ts)
+        logging_helper.info(ts, 'deepcopy', '1')
         self.db.save_data(ts, storage_mode='gridfs', update_all=True, exclude=['extra2'])
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         assert res
@@ -305,6 +323,7 @@ class TestDatabase():
 
     def test_delete_gridfs(self):
         ts = copy.deepcopy(self.test_ts)
+        logging_helper.info(ts, 'deepcopy', '1')
         self.db.save_data(ts, storage_mode='gridfs', update_all=True, exclude=['extra2'])
         res = self.db['wf_TimeSeries'].find_one({'_id': ts['_id']})
         gfsh = gridfs.GridFS(self.db)
@@ -316,6 +335,9 @@ class TestDatabase():
         ts1 = copy.deepcopy(self.test_ts)
         ts2 = copy.deepcopy(self.test_ts)
         ts3 = copy.deepcopy(self.test_ts)
+        logging_helper.info(ts1, 'deepcopy', '1')
+        logging_helper.info(ts2, 'deepcopy', '1')
+        logging_helper.info(ts3, 'deepcopy', '1')
         self.db.save_data(ts1, 'gridfs')
         self.db.save_data(ts2, 'gridfs')
         self.db.save_data(ts3, 'gridfs')
@@ -350,6 +372,9 @@ class TestDatabase():
         seis1 = copy.deepcopy(self.test_seis)
         seis2 = copy.deepcopy(self.test_seis)
         seis3 = copy.deepcopy(self.test_seis)
+        logging_helper.info(seis1, 'deepcopy', '1')
+        logging_helper.info(seis2, 'deepcopy', '1')
+        logging_helper.info(seis3, 'deepcopy', '1')
         self.db.save_data(seis1, 'gridfs')
         self.db.save_data(seis2, 'gridfs')
         self.db.save_data(seis3, 'gridfs')
@@ -383,6 +408,9 @@ class TestDatabase():
         ts1 = copy.deepcopy(self.test_ts)
         ts2 = copy.deepcopy(self.test_ts)
         ts3 = copy.deepcopy(self.test_ts)
+        logging_helper.info(ts1, 'deepcopy', '1')
+        logging_helper.info(ts2, 'deepcopy', '1')
+        logging_helper.info(ts3, 'deepcopy', '1')
         ts_ensemble = TimeSeriesEnsemble()
         ts_ensemble.member.append(ts1)
         ts_ensemble.member.append(ts2)
@@ -407,6 +435,9 @@ class TestDatabase():
         seis1 = copy.deepcopy(self.test_seis)
         seis2 = copy.deepcopy(self.test_seis)
         seis3 = copy.deepcopy(self.test_seis)
+        logging_helper.info(seis1, 'deepcopy', '1')
+        logging_helper.info(seis2, 'deepcopy', '1')
+        logging_helper.info(seis3, 'deepcopy', '1')
         seis_ensemble = SeismogramEnsemble()
         seis_ensemble.member.append(seis1)
         seis_ensemble.member.append(seis2)
@@ -432,6 +463,9 @@ class TestDatabase():
         ts1 = copy.deepcopy(self.test_ts)
         ts2 = copy.deepcopy(self.test_ts)
         ts3 = copy.deepcopy(self.test_ts)
+        logging_helper.info(ts1, 'deepcopy', '1')
+        logging_helper.info(ts2, 'deepcopy', '1')
+        logging_helper.info(ts3, 'deepcopy', '1')
         ts_ensemble = TimeSeriesEnsemble()
         ts_ensemble.member.append(ts1)
         ts_ensemble.member.append(ts2)
@@ -447,6 +481,9 @@ class TestDatabase():
         seis1 = copy.deepcopy(self.test_seis)
         seis2 = copy.deepcopy(self.test_seis)
         seis3 = copy.deepcopy(self.test_seis)
+        logging_helper.info(seis1, 'deepcopy', '1')
+        logging_helper.info(seis2, 'deepcopy', '1')
+        logging_helper.info(seis3, 'deepcopy', '1')
         seis_ensemble = SeismogramEnsemble()
         seis_ensemble.member.append(seis1)
         seis_ensemble.member.append(seis2)
@@ -492,6 +529,9 @@ def test_read_distributed_data(spark_context):
     ts1 = copy.deepcopy(test_ts)
     ts2 = copy.deepcopy(test_ts)
     ts3 = copy.deepcopy(test_ts)
+    logging_helper.info(ts1, 'deepcopy', '1')
+    logging_helper.info(ts2, 'deepcopy', '1')
+    logging_helper.info(ts3, 'deepcopy', '1')
 
     db.save_data(ts1, 'gridfs')
     db.save_data(ts2, 'gridfs')
@@ -537,6 +577,9 @@ def test_read_distributed_data_dask():
     ts1 = copy.deepcopy(test_ts)
     ts2 = copy.deepcopy(test_ts)
     ts3 = copy.deepcopy(test_ts)
+    logging_helper.info(ts1, 'deepcopy', '1')
+    logging_helper.info(ts2, 'deepcopy', '1')
+    logging_helper.info(ts3, 'deepcopy', '1')
 
     db.save_data(ts1, 'gridfs')
     db.save_data(ts2, 'gridfs')

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -170,6 +170,9 @@ class TestDatabase():
         nodes = ts.get_nodes()
         assert str(nodes) == str(loaded_nodes)
 
+        with pytest.raises(MsPASSError, match="Failed to save the history object as a new insertion"):
+            self.db._save_history(ts)
+
     def test_update_metadata(self):
         ts = copy.deepcopy(self.test_ts)
         logging_helper.info(ts, 'deepcopy', '1')


### PR DESCRIPTION
This commit fixes the logic that the inserted id of the history object should be the UUID set in the processing history class.

Since deep-copy in testing will copy the same UUID and result in mongo duplicate-key-error, modifications are made, i.e. using logging_helper to create a new node.