### PR TITLE
Improve preprocessing

### DIFF
--- a/python/mspasspy/preprocessing/seed/ensembles.py
+++ b/python/mspasspy/preprocessing/seed/ensembles.py
@@ -582,9 +582,8 @@ def load_site_data(db,ens):
                 d['site_elev']=siterec['elevation']
                 d['site_id']=siterec['site_id']
                 if n>1:
-                    message = ('Muliple (%d) matches found for net %s sta %s with reference time %f'
-                               % [n,net,sta,t0])
-                    d.elog.log_error('load_site_data',message,ErrorSeverity.Complain)
+                    message = "Multiple ({n}) matches found for net={net} and sta={sta} with reference time {t0}".format(n=n,net=net,sta=sta,t0=t0)
+                    d.elog.log_error('load_site_data',message,ErrorSeverity.Complaint)
         return ens
     except Exception as err:
         raise MsPASSError('Something threw an unexpected exception',
@@ -635,9 +634,8 @@ def load_channel_data(db,ens):
                 # that is what find_one returns.  We use the count to make
                 # the eror message cleaer
                     chanrec=dbchannel.find_one(query)
-                    message = ('Muliple (%d) matches found for net=%s sta=% chan=%s loc=%s with reference time %s'
-                               % [n,net,sta,chan,loc,t0])
-                    d.elog.log_error('load_site_data',message,ErrorSeverity.Complain)
+                    message = "Multiple ({n}) matches found for net={net} and sta={sta} with reference time {t0}".format(n=n,net=net,sta=sta,t0=t0)
+                    d.elog.log_error('load_site_data',message,ErrorSeverity.Complaint)
                 d['site_lat']=chanrec['latitude']
                 d['site_lon']=chanrec['longitude']
                 d['site_elev']=chanrec['elevation']


### PR DESCRIPTION
This branch has three changes.  Two I doubt you will have problems with but item 3 below will require a decision from on how to handle it.  First, here are the things changed:
1.  In finalizing the raw data tutorial, which is a prototype for our benchmark workflow the the usarray data, I fixed a couple of minor bugs in the ensemble.py file.  
2. As an aid to sorting out some additional site and channel metadata problems I developed two functions I think are useful additions to the database api.  These functions are called *site_report* and *channel_report*.  The produce a nicely formatted display of key metadata for a selected equal match to one or more of the keys net, sta, chan, loc.  I put them in the database.py module because I thought they belonged there.  I do not, however, think they belong as methods in the Database class.   The alternative is to create a new module in preprocessing/seed because these functions depend completely on seed name codes, which we should not treat as a requirement for site and channel.  (In fact, in the revisions to the documentation I emphasize that point and give a reason why it isn't at all generic.)   I can see reasons for both organizations.   The seed model might actually be better as I can see a set of seed specific functions we might want to develop that belong in preprocessing.    A bit depends on what additional functionality we think might be needed for manipulating site and channel during preprocessing.  
3. To get this to work at all I had to do a set of fixes to database.py to work around the mishandling of dead data and data with empty history chains.  Both issues aborted a call to save_data when either condition was present.  I think you may be doing a parallel fix so I suggest you look at what I did and make sure you fixed the same problems.  If not you will need to accept my change or add a (perhaps cleaner) solution to the same problem.

The only sure way to test this stuff is to run the raw data tutorial I'm about to also check in on the tutorial branch.  Warning that going through all the steps will consume a couple of hours by the time you read the material, absorb it, and run the steps (some take a while to complete due to the collection size or the data volume (the last step)).  