### PR TITLE
Add get_response method for Database class

### DIFF
--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -878,7 +878,7 @@ class Database(pymongo.database.Database):
         # this returns a warning that count is depricated but
         # I'm getting confusing results from google search on the
         # topic so will use this for now
-        nrec = matches.count_documents()
+        nrec = matches.count()
         if (nrec <= 0):
             return True
         else:
@@ -918,7 +918,7 @@ class Database(pymongo.database.Database):
         # this returns a warning that count is depricated but
         # I'm getting confusing results from google search on the
         # topic so will use this for now
-        nrec = matches.count_documents()
+        nrec = matches.count()
         if (nrec <= 0):
             return True
         else:

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -878,7 +878,7 @@ class Database(pymongo.database.Database):
         # this returns a warning that count is depricated but
         # I'm getting confusing results from google search on the
         # topic so will use this for now
-        nrec = matches.count()
+        nrec = matches.count_documents()
         if (nrec <= 0):
             return True
         else:
@@ -918,7 +918,7 @@ class Database(pymongo.database.Database):
         # this returns a warning that count is depricated but
         # I'm getting confusing results from google search on the
         # topic so will use this for now
-        nrec = matches.count()
+        nrec = matches.count_documents()
         if (nrec <= 0):
             return True
         else:
@@ -1384,7 +1384,7 @@ class Database(pymongo.database.Database):
                               + "Specify at least time but a loc code if is not truly null",
                               "Fatal")
 
-    def get_response(self,net=None,sta=None,chan=None,loc=None,time=None):
+    def get_response(self, net=None, sta=None, chan=None, loc=None, time=None):
         """
         Returns an obspy Response object for seed channel defined by 
         the standard keys net, sta, chan, and loc and a time stamp.  
@@ -1406,38 +1406,38 @@ class Database(pymongo.database.Database):
           required.   Can be passed as either a UTCDateTime object or 
           a raw epoch time stored as a python float. 
         """
-        if sta==None or chan==None or net==None or time==None:
+        if sta == None or chan == None or net == None or time == None:
             raise MsPASSError('get_response:  missing one of required arguments:  '
-                              +'net, sta, chan, or time','Invalid')
-        query={
-              'net' : net,
-              'sta' : sta,
-              'chan' : chan,
-            }
-        if loc!=None:
-            query['loc']=loc
+                              + 'net, sta, chan, or time', 'Invalid')
+        query = {
+            'net': net,
+            'sta': sta,
+            'chan': chan,
+        }
+        if loc != None:
+            query['loc'] = loc
         else:
-            loc='  '  # set here but not used
-        if isinstance(time,UTCDateTime):
-            t0=time.timestamp
+            loc = '  '  # set here but not used
+        if isinstance(time, UTCDateTime):
+            t0 = time.timestamp
         else:
-            t0=time
-        query['starttime']={'$lt' : t0}
-        query['endtime']={'$gt' : t0}
-        n=self.channel.count_documents(query)
-        if n==0:
+            t0 = time
+        query['starttime'] = {'$lt': t0}
+        query['endtime'] = {'$gt': t0}
+        n = self.channel.count_documents(query)
+        if n == 0:
             print('No matching documents found in channel for ',
-                  net,":",sta,":","chan",chan,"->",loc,"<-"," at time=",
+                  net, ":", sta, ":", "chan", chan, "->", loc, "<-", " at time=",
                   UTCDateTime(t0))
             return None
-        elif n>1:
-            print(n,' matching documents found in channel for ',
-                  net,":",sta,":","chan","->",loc,"<-"," at time=",
+        elif n > 1:
+            print(n, ' matching documents found in channel for ',
+                  net, ":", sta, ":", "chan", "->", loc, "<-", " at time=",
                   UTCDateTime(t0))
             print('There should be just one - returning the first one found')
-        doc=self.channel.find_one(query)
-        s=doc['serialized_channel_data']
-        chan=pickle.loads(s)
+        doc = self.channel.find_one(query)
+        s = doc['serialized_channel_data']
+        chan = pickle.loads(s)
         return chan.response
 
     def save_catalog(self, cat, verbose=False):

--- a/python/mspasspy/db/database.py
+++ b/python/mspasspy/db/database.py
@@ -1384,6 +1384,62 @@ class Database(pymongo.database.Database):
                               + "Specify at least time but a loc code if is not truly null",
                               "Fatal")
 
+    def get_response(self,net=None,sta=None,chan=None,loc=None,time=None):
+        """
+        Returns an obspy Response object for seed channel defined by 
+        the standard keys net, sta, chan, and loc and a time stamp.  
+        Input time can be a UTCDateTime or an epoch time stored as a float.
+        
+        :param db:  mspasspy Database handle containing a channel collection
+          to be queried
+        :param net: seed network code (required)
+        :param sta: seed station code (required)
+        :param chan:  seed channel code (required)
+        :param loc:  seed net code.  If None loc code will not be 
+          included in the query.  If loc is anything else it is passed 
+          as a literal.  Sometimes loc codes are not defined by in the 
+          seed data and are literal two ascii space characters.  If so 
+          MongoDB translates those to "".   Use loc="" for that case or 
+          provided the station doesn't mix null and other loc codes use None. 
+        :param time:  time stamp for which the response is requested.  
+          seed metadata has a time range for validity this field is 
+          required.   Can be passed as either a UTCDateTime object or 
+          a raw epoch time stored as a python float. 
+        """
+        if sta==None or chan==None or net==None or time==None:
+            raise MsPASSError('get_response:  missing one of required arguments:  '
+                              +'net, sta, chan, or time','Invalid')
+        query={
+              'net' : net,
+              'sta' : sta,
+              'chan' : chan,
+            }
+        if loc!=None:
+            query['loc']=loc
+        else:
+            loc='  '  # set here but not used
+        if isinstance(time,UTCDateTime):
+            t0=time.timestamp
+        else:
+            t0=time
+        query['starttime']={'$lt' : t0}
+        query['endtime']={'$gt' : t0}
+        n=self.channel.count_documents(query)
+        if n==0:
+            print('No matching documents found in channel for ',
+                  net,":",sta,":","chan",chan,"->",loc,"<-"," at time=",
+                  UTCDateTime(t0))
+            return None
+        elif n>1:
+            print(n,' matching documents found in channel for ',
+                  net,":",sta,":","chan","->",loc,"<-"," at time=",
+                  UTCDateTime(t0))
+            print('There should be just one - returning the first one found')
+        doc=self.channel.find_one(query)
+        s=doc['serialized_channel_data']
+        chan=pickle.loads(s)
+        return chan.response
+
     def save_catalog(self, cat, verbose=False):
         """
         Save the contents of an obspy Catalog object to MongoDB

--- a/python/tests/data/TA.035A.xml
+++ b/python/tests/data/TA.035A.xml
@@ -1,0 +1,524 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.1">
+  <Source>IRIS-DMC</Source>
+  <Sender>IRIS-DMC</Sender>
+  <Module>IRIS WEB SERVICE: fdsnws-station | version: 1.1.47</Module>
+  <ModuleURI>http://service.iris.edu/fdsnws/station/1/query?starttime=2011-03-11T04%3A46%3A24.000000&amp;endtime=2011-03-18T05%3A46%3A24.000000&amp;network=TA&amp;station=035A&amp;channel=BH%3F&amp;level=response&amp;format=xml</ModuleURI>
+  <Created>2021-02-19T18:16:37.000000Z</Created>
+  <Network code="TA" startDate="2003-01-01T00:00:00.000000Z" restrictedStatus="open">
+    <Description>USArray Transportable Array (EarthScope_TA)</Description>
+    <Identifier type="DOI">10.7914/SN/TA
+   </Identifier>
+    <TotalNumberStations>1893</TotalNumberStations>
+    <SelectedNumberStations>1</SelectedNumberStations>
+    <Station code="035A" startDate="2010-01-12T00:00:00.000000Z" endDate="2011-11-14T23:59:59.000000Z" restrictedStatus="open">
+      <Latitude unit="DEGREES">26.937901</Latitude>
+      <Longitude unit="DEGREES">-98.102303</Longitude>
+      <Elevation>29.0</Elevation>
+      <Site>
+        <Name>Encino, TX, USA</Name>
+      </Site>
+      <CreationDate>2010-01-12T00:00:00.000000Z</CreationDate>
+      <TotalNumberChannels>37</TotalNumberChannels>
+      <SelectedNumberChannels>3</SelectedNumberChannels>
+      <Channel code="BHE" startDate="2010-01-12T00:00:00.000000Z" endDate="2011-11-14T17:40:00.000000Z" restrictedStatus="open" locationCode="">
+        <Latitude unit="DEGREES">26.937901</Latitude>
+        <Longitude unit="DEGREES">-98.102303</Longitude>
+        <Elevation>29.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">89.7</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">40.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.00025</ClockDrift>
+        <CalibrationUnits>
+          <Name>V</Name>
+          <Description>emf in volts</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Description>Guralp CMG3T/Quanterra 330 Linear Phase Composite</Description>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>630907000.0</Value>
+            <Frequency>0.2</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>velocity in meters per second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>digital counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>velocity in meters per second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>emf in volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>571400000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">0.2</NormalizationFrequency>
+              <Zero number="0">
+                <Real minusError="0.0" plusError="0.0">0.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real minusError="0.0" plusError="0.0">0.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Pole number="0">
+                <Real minusError="0.0" plusError="0.0">-0.03701</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.03701</Imaginary>
+              </Pole>
+              <Pole number="1">
+                <Real minusError="0.0" plusError="0.0">-0.03701</Real>
+                <Imaginary minusError="0.0" plusError="0.0">-0.03701</Imaginary>
+              </Pole>
+              <Pole number="2">
+                <Real minusError="0.0" plusError="0.0">-1131.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real minusError="0.0" plusError="0.0">-1005.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real minusError="0.0" plusError="0.0">-502.7</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1504.2</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>emf in volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">40.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>419430.0</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <Coefficients>
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+              <Numerator minusError="0.0" plusError="0.0">1.67168e-13</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">5.2013e-07</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-4.60131e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">6.92017e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000455642</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000827269</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00352524</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00128478</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">6.73911e-05</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00483673</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0101324</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0149433</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0156879</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00951639</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00590211</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0306325</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0620254</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0950787</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.129863</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.144116</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.852339</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.160728</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.135207</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0960015</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0611088</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0288906</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00415915</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.010815</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0163994</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0151374</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00999424</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0045623</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.000184309</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00145576</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00357573</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000786725</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000477516</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">8.02779e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-4.51237e-06</Numerator>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">40.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.5</Delay>
+              <Correction>0.5</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="BHN" startDate="2010-01-12T00:00:00.000000Z" endDate="2011-11-14T17:40:00.000000Z" restrictedStatus="open" locationCode="">
+        <Latitude unit="DEGREES">26.937901</Latitude>
+        <Longitude unit="DEGREES">-98.102303</Longitude>
+        <Elevation>29.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">359.7</Azimuth>
+        <Dip unit="DEGREES">0.0</Dip>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">40.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.00025</ClockDrift>
+        <CalibrationUnits>
+          <Name>V</Name>
+          <Description>emf in volts</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Description>Guralp CMG3T/Quanterra 330 Linear Phase Composite</Description>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>630907000.0</Value>
+            <Frequency>0.2</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>velocity in meters per second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>digital counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>velocity in meters per second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>emf in volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>571400000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">0.2</NormalizationFrequency>
+              <Zero number="0">
+                <Real minusError="0.0" plusError="0.0">0.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real minusError="0.0" plusError="0.0">0.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Pole number="0">
+                <Real minusError="0.0" plusError="0.0">-0.03701</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.03701</Imaginary>
+              </Pole>
+              <Pole number="1">
+                <Real minusError="0.0" plusError="0.0">-0.03701</Real>
+                <Imaginary minusError="0.0" plusError="0.0">-0.03701</Imaginary>
+              </Pole>
+              <Pole number="2">
+                <Real minusError="0.0" plusError="0.0">-1131.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real minusError="0.0" plusError="0.0">-1005.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real minusError="0.0" plusError="0.0">-502.7</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1504.2</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>emf in volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">40.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>419430.0</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <Coefficients>
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+              <Numerator minusError="0.0" plusError="0.0">1.67168e-13</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">5.2013e-07</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-4.60131e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">6.92017e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000455642</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000827269</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00352524</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00128478</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">6.73911e-05</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00483673</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0101324</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0149433</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0156879</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00951639</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00590211</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0306325</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0620254</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0950787</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.129863</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.144116</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.852339</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.160728</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.135207</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0960015</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0611088</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0288906</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00415915</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.010815</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0163994</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0151374</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00999424</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0045623</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.000184309</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00145576</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00357573</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000786725</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000477516</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">8.02779e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-4.51237e-06</Numerator>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">40.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.5</Delay>
+              <Correction>0.5</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+      <Channel code="BHZ" startDate="2010-01-12T00:00:00.000000Z" endDate="2011-11-14T17:40:00.000000Z" restrictedStatus="open" locationCode="">
+        <Latitude unit="DEGREES">26.937901</Latitude>
+        <Longitude unit="DEGREES">-98.102303</Longitude>
+        <Elevation>29.0</Elevation>
+        <Depth>0.0</Depth>
+        <Azimuth unit="DEGREES">0.0</Azimuth>
+        <Dip unit="DEGREES">-90.0</Dip>
+        <Type>GEOPHYSICAL</Type>
+        <SampleRate unit="SAMPLES/S">40.0</SampleRate>
+        <ClockDrift unit="SECONDS/SAMPLE">0.00025</ClockDrift>
+        <CalibrationUnits>
+          <Name>V</Name>
+          <Description>emf in volts</Description>
+        </CalibrationUnits>
+        <Sensor>
+          <Description>Guralp CMG3T/Quanterra 330 Linear Phase Composite</Description>
+        </Sensor>
+        <Response>
+          <InstrumentSensitivity>
+            <Value>630907000.0</Value>
+            <Frequency>0.2</Frequency>
+            <InputUnits>
+              <Name>M/S</Name>
+              <Description>velocity in meters per second</Description>
+            </InputUnits>
+            <OutputUnits>
+              <Name>COUNTS</Name>
+              <Description>digital counts</Description>
+            </OutputUnits>
+          </InstrumentSensitivity>
+          <Stage number="1">
+            <PolesZeros>
+              <InputUnits>
+                <Name>M/S</Name>
+                <Description>velocity in meters per second</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>V</Name>
+                <Description>emf in volts</Description>
+              </OutputUnits>
+              <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+              <NormalizationFactor>571400000.0</NormalizationFactor>
+              <NormalizationFrequency unit="HERTZ">0.2</NormalizationFrequency>
+              <Zero number="0">
+                <Real minusError="0.0" plusError="0.0">0.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Zero number="1">
+                <Real minusError="0.0" plusError="0.0">0.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Zero>
+              <Pole number="0">
+                <Real minusError="0.0" plusError="0.0">-0.03701</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.03701</Imaginary>
+              </Pole>
+              <Pole number="1">
+                <Real minusError="0.0" plusError="0.0">-0.03701</Real>
+                <Imaginary minusError="0.0" plusError="0.0">-0.03701</Imaginary>
+              </Pole>
+              <Pole number="2">
+                <Real minusError="0.0" plusError="0.0">-1131.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+              <Pole number="3">
+                <Real minusError="0.0" plusError="0.0">-1005.0</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+              <Pole number="4">
+                <Real minusError="0.0" plusError="0.0">-502.7</Real>
+                <Imaginary minusError="0.0" plusError="0.0">0.0</Imaginary>
+              </Pole>
+            </PolesZeros>
+            <StageGain>
+              <Value>1504.2</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="2">
+            <Coefficients>
+              <InputUnits>
+                <Name>V</Name>
+                <Description>emf in volts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">40.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.0</Delay>
+              <Correction>0.0</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>419430.0</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+          <Stage number="3">
+            <Coefficients>
+              <InputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </InputUnits>
+              <OutputUnits>
+                <Name>COUNTS</Name>
+                <Description>digital counts</Description>
+              </OutputUnits>
+              <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+              <Numerator minusError="0.0" plusError="0.0">1.67168e-13</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">5.2013e-07</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-4.60131e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">6.92017e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000455642</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000827269</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00352524</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00128478</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">6.73911e-05</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00483673</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0101324</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0149433</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0156879</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00951639</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00590211</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0306325</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0620254</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0950787</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.129863</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.144116</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.852339</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.160728</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.135207</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0960015</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0611088</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0288906</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00415915</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.010815</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.0163994</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0151374</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00999424</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.0045623</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.000184309</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.00145576</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-0.00357573</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000786725</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">0.000477516</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">8.02779e-06</Numerator>
+              <Numerator minusError="0.0" plusError="0.0">-4.51237e-06</Numerator>
+            </Coefficients>
+            <Decimation>
+              <InputSampleRate unit="HERTZ">40.0</InputSampleRate>
+              <Factor>1</Factor>
+              <Offset>0</Offset>
+              <Delay>0.5</Delay>
+              <Correction>0.5</Correction>
+            </Decimation>
+            <StageGain>
+              <Value>1.0</Value>
+              <Frequency>0.2</Frequency>
+            </StageGain>
+          </Stage>
+        </Response>
+      </Channel>
+    </Station>
+  </Network>
+</FDSNStationXML>

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -592,6 +592,9 @@ class TestDatabase():
             r = self.db.get_response(net, sta, chan, loc, time)
             r0 = inv.get_response("TA.035A..BHE", time)
             assert r == r0
+        with pytest.raises(MsPASSError, match='missing one of required arguments'):
+            self.db.get_response()
+        assert self.db.get_response(net='TA', sta='036A', chan='BHE', time=time) is None
 
     def teardown_class(self):
         try:

--- a/python/tests/db/test_db.py
+++ b/python/tests/db/test_db.py
@@ -4,6 +4,7 @@ import os
 import dask.bag
 import gridfs
 import numpy as np
+import obspy 
 import pytest
 import sys
 
@@ -71,6 +72,10 @@ class TestDatabase():
         self.test_ts['site_id'] = site_id
         self.test_ts['source_id'] = source_id
         self.test_ts['channel_id'] = channel_id
+
+        # save inventory to db
+        inv = obspy.read_inventory('python/tests/data/TA.035A.xml')
+        self.db.save_inventory(inv)
 
     def test_init(self):
         db_schema = DatabaseSchema("mspass_lite.yaml")
@@ -577,6 +582,16 @@ class TestDatabase():
         for i in range(3):
             assert np.isclose(res.member[i].data, seis_ensemble.member[i].data).all()
 
+    def test_get_response(self):
+        inv = obspy.read_inventory('python/tests/data/TA.035A.xml')
+        net = 'TA'
+        sta = '035A'
+        loc = ''
+        time = 1263254400.0+100.0
+        for chan in ['BHE', 'BHN', 'BHZ']:
+            r = self.db.get_response(net, sta, chan, loc, time)
+            r0 = inv.get_response("TA.035A..BHE", time)
+            assert r == r0
 
     def teardown_class(self):
         try:
@@ -680,7 +695,6 @@ def test_read_distributed_data_dask():
 
     client = Client('localhost')
     client.drop_database('mspasspy_test_db')
-
 
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
This is a simple change to the current database.py file that was split from master only about 2 hours ago.  The only changes are the addition of a new get_response method to Database.  There are complete docstrings but this method is needed to complete a tutorial handling response data for MsPASS - there is presently only a skeleton in the tutorial repository. 

This small test program is how I tested this.  I does not mesh with the automated test setup in this repository, but I'll leave that to someone else.   This little program can be run after completion of the getting started tutorial.  The idea is a user could run the response tutorial after getting started and run a variant of this little program in jupyter.  Anyway, here it is if you want to try it - noting you will at least need to run part of the getting started tutorial to build site and channel for this to work:
```
from mspasspy.db.database import Database
from mspasspy.db.client import Client as DBClient
dbclient=DBClient()
db=Database(dbclient,'getting_started')
net='TA'
sta='035A'
loc=''
time=1263254400.0+100.0
for chan in ['BHE','BHN','BHZ']:
    r=db.get_response(net,sta,chan,loc,time)
    #r=db.get_response(net,sta,chan,time=time)
    print(r)
    r.plot(0.001)
```