### PR TITLE
Add two new documentation pages

### DIFF
--- a/docs/source/user_manual.rst
+++ b/docs/source/user_manual.rst
@@ -4,9 +4,11 @@ User's Manual
 .. toctree::
     :maxdepth: 2
 
+    user_manual/introduction
     user_manual/data_object_design_concepts
     user_manual/time_standard_constraints
-    user_manual/processing_history_concepts
     user_manual/database_concepts
     user_manual/CRUD_operations
+    user_manual/handling_errors
+    user_manual/processing_history_concepts
     user_manual/adapting_algorithms

--- a/docs/source/user_manual/handling_errors.rst
+++ b/docs/source/user_manual/handling_errors.rst
@@ -1,0 +1,201 @@
+Handling Errors
+===================
+
+Overview
+~~~~~~~~~~~~~~
+Errors are a universal issue in large scale data processing.
+In single threaded applications it was common to follow the classic unix
+model of writing error messages to stderr.  Anyone processing large
+amounts of data that can generate hundreds to thousands of error messages
+know that stderr logging is problematic because the critical errors
+can be hard to find in the debris.  A common solution used for single
+threading was to use a log file that could be searched post mortem to
+find problems.   In a multithreaded situation that solution can work, but
+requires specialized io libraries to avoid write collisions if two threads
+try to write the to same file.  An example that may be familiar to many
+seismologists of that approach is the elog library used in
+`Antelope<https://brtt.com>`__.  That approach can work for a shared memory
+system but is more problematic in a large cluster of distributed machines
+or (worse) a cloud system.  In a distributed system a centralized error
+logger would need to maintain a connection to every running process, which
+would to a challenge to implement.
+
+The above issues led us to a completely different solution for error logging.
+We include an ErrorLogger class as a base class to all supported data
+objects.  That model simplifies the error handling because the error
+handling model can be stated as two simple rules:
+
+1.  If there is any error that the user needs to be warned about, post
+    an informative message to the error log.  Error are not always black
+    and white so the message should define the severity level of the error.
+2.  If the error invalidates the data, mark the data dead.  We expand
+    on this concept further below in the section titled "Kills".
+
+This section is organized around three key concepts used in the
+error handling system of MsPASS:   standardized exception handling,
+the error logger api, and concepts related to marking data dead.  The
+last item has two important subtopics:  the kill concept and
+special class we tag with the descriptive, albeit perhaps overly cute,
+name of :code:`Undertaker`.
+
+Exceptions and Error Handlers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Any book on programming in any language will address the issue of error handling.
+The reason, of course, is that most algorithms have limitations on
+what they receive as inputs or can evolve to a state that is untenable.
+There are multiple standard ways to handle errors.   In MsPASS we aimed to
+treat errors with one of three approaches.
+1.  The python language is flexible, but standard practice encourages the
+    use of the try-raise-except construct (the try-throw-catch keywords in C++).
+    We use that exception mechanism internally to handle most error conditions.
+    To provide some regularity any error raised by a MsPASS function or
+    method will be the exception class called MsPASSError.   Following
+    standard practice the MsPASSError is defined as a subclass of the
+    base class Exception.  That allows generic error handlers like the
+    following to catch MsPASSError exceptions as described in most
+    books and online python tutorials
+    (`Follow this link for a good example<https://medium.com/better-programming/a-comprehensive-guide-to-handling-exceptions-in-python-7175f0ce81f7>`__)
+2.  As with most python packages, with some algorithms we sometimes return
+    something that can indicate full or partial success.   We reserve that
+    model to situations where "partial success" is not really an error but
+    the result of an algorithm that is expected to behave in different ways
+    with different inputs.  For example, the save_inventory method of
+    `database<https://wangyinz.github.io/mspass/python_api/mspasspy.db.html#module-mspasspy.db.database>`__
+    returns a tuple with three numbers: number of site documents added,
+    number of channel documents added, and the number of stations in the
+    obspy Inventory object that the method received.  The result is dependent
+    on history of what was saved previously because this particular algorithm
+    tests the input to not add duplicates to the database.
+3.  Processing functions in MsPASS that are properly designed for the
+    framework MUST obey a very important rule:  a function to be run in
+    parallel should never throw an exception, but use the error log and (optional)
+    kill method described below.
+
+Error Logger
+~~~~~~~~~~~~~~
+
+As discussed in the overview section above, handling errors in a parallel
+environment presents special problems.  A key issue is that the schedulers
+MsPASS supports (Spark and Dask) both will abort a job if any function
+throws an unhandled exception.  For that reason, if a MsPASS processing
+function ever throws an exception it is a bug.  Instead, we always aim
+to handle errors with what we call our ErrorLogger and a classic approach
+using a kill mechanism.
+
+The atomic data objects of MsPASS, which we call TimeSeries and Seismogram,
+are defined and implemented in C++.  (They are bound to python through
+wrappers using a package called pybind11.)  Both atomic data objects
+have a C++ class called `ErrorLogger<https://wangyinz.github.io/mspass/cxx_api/mspass.html#mspass-namespace>`__
+as a public attribute we define with the symbol :code:`elog`.  That mechanism
+allows processing functions to handle all exceptions without aborting
+through constructs similar to the following pythonic pseudocode:
+
+.. code-block:: python
+
+   code that may throw an error processing data object "d"
+   except MsPASSError a merr:
+     d.elog.log_error(merr)
+     if merr.severity() == ErrorSeverity.Invalid:
+       d.kill()
+   except Exception as err:
+     d.log.log_error('Unexcepted exception: more details','Invalid')
+     d.kill()
+
+The kill method is described further in the next section.  The key point
+is that generic error handlers catch any exceptions and post message to
+the ErrorLogger carried with the data in a container
+with the symbolic name elog.   An error posted to the ErrorLogger
+always contains two components:  (1) a (hopefully informative)
+string that describes the error, and (2) a severity tag.   The
+`class description<https://wangyinz.github.io/mspass/cxx_api/mspass.html#mspass-namespace>`__
+describes the severity method that returns a special class called
+ErrorSeverity.   ErrorSeverity is technically a binding to a C++ enum
+class that defines a finite set of values that should be understood
+as follows:
+
+:code:`Fatal`: A serious error that should cause the job to abort.   This
+is reserved only for completely unrecoverable errors such as a malloc error.
+
+:code:`Invalid`: This error indicates the algorithm could not produce valid
+data.  Data with Invalid errors will always be marked dead.
+
+:code:`Suspect`:  Suspect is reserved for the condition where the datum
+is not killed, but the algorithm that posted it wants to give a hint that
+you should consider not using it for additional processing.  There are currently
+no examples of this error being posted, but we include it in the api
+to allow that option.
+
+:code:`Complaint`:  A complaint is posted for an error that was handled and
+fully corrected.   Complaints are posted largely as informational messages
+to warn the user there were problems with data they may want to correct
+to avoid problems with different downstream algorithms.  Such errors can
+also often be useful in determining why a later stage of processing aborts.
+
+:code:`Debug`:  Reserved for verbose logging to track a problem.  Useful to
+insert in a long running job where something is going wrong that is
+yielding invalid data but the job is not aborting or logging errors that
+define the problem.
+
+:code:`Informative`:  Used for very verbose options on some algorithms to
+extract some auxiliary information needed for some other purpose.
+
+A final point about error logs is to how they are preserved.  Error
+messages should always be examined after a processing sequence is completed
+to appraise the validity of the result.  With a large data set is it is
+very easy to generate huge error logs.  To make the result more manageable
+all save operators automatically write any error log entries to
+a special collection in MongoDB we call the :code:`elog` collection.
+
+Kills
+~~~~~~~~~
+The approach of marking a piece of seismic data bad/dead is familiar to
+anyone who has ever done seismic reflection processing.  All seismic
+processing systems have a set of trace editing functions to mark
+bad data.  That approach goes back to the earliest days of seismic reflection
+processing as evidenced by a trace id field (technically an
+unsigned int16) in SEGY that when set to a particular value (2) defines
+that datum as dead.
+
+The kill concept is useful in the MsPASS framework as a way to simplify
+parallel workflows.  Spark and Dask both use a mechanism to abstract
+an entire data set as a single container (called an RDD in Spark and a "Bag"
+in Dask).  As described in detail in the section of this manual on
+parallel processing, the model used by MsPASS assumes a processing function
+to run in parallel applies the same function to every member of the dataset
+defined by the RDD or Bag container.  The kill mechanism is a simple
+mechanism to define data that should be considered no longer valid.   All
+properly designed python functions in MsPASS automatically do nothing if
+data are marked dead leaving the dead data as elements of the RDD/Bag.
+
+A final point is that if a job is expected to kill a large fraction of data
+there is a point where it becomes more efficient to clear the dataset of
+dead data.   That needs to be done with some care if one wishes to preserve
+error log entries that document why a datum was killed.   The
+:code:`Undertaker` class, which described in the next section was designed
+to handle such issues.
+
+Undertaker
+~~~~~~~~~~~~~
+The class name is a programming joke, but the name is descriptive;  its jobs
+is to deal with dead data.  It has three basic methods that can be applied in
+a serial job:
+
+1.  The :code:`bury_the_dead` is the recommended method for most workflows
+    to handle dead data.  It accepts TimeSeries, Seismogram, and ensembles of
+    either as input.  It saves error logs and metadata for killed data to a
+    special collection we call "graveyard".  (NOT YET IMPLEMENTED AND SUBJECT
+    TO CHANGE).   For ensembles the function returns an edited version of the
+    ensemble with the dead data removed.
+2.  The :code:`cremate` method can only be applied to ensembles.  It
+    clears the dead data members from an ensemble and returns a clean
+    copy with he dead data removed.  We call it :code:`cremate` because
+    all traces of the data vanish; neither the error log or any identifiers
+    of the destroyed data will be retained.
+3.  The :code:`bring_out_your_dead` method, other than being the best python programming
+    joke ever, is more specialized.  It is only relevant for
+    ensembles.  It returns two ensembles:  one with all the live and one
+    with all the dead data.  That approach can be used, for example, in
+    testing automatic editing code.  An interactive job to evaluate
+    how well the editing worked could use this method.
+
+For parallel workflows - NEEDS SOMETHING WHEN THAT IS FINISHED.

--- a/docs/source/user_manual/introduction.rst
+++ b/docs/source/user_manual/introduction.rst
@@ -1,8 +1,12 @@
+.. _user_manual_introduction:
+
 Introduction
 =================================
+
 MsPASS Features
 ~~~~~~~~~~~~~~~~
-MsPASS is an acronymn that comes from Massively Parallel Analysis System for Seismologists.
+
+MsPASS is an acronym that comes from Massively Parallel Analysis System for Seismologists.
 We begin with some key features of MsPASS.
 
 -   As the name suggests MsPASS is a domain-specific package for seismologists.
@@ -10,6 +14,7 @@ We begin with some key features of MsPASS.
     broad.  It includes exploration geophysicists and anyone in any field that
     needs to work with data that match the data models described in this
     manual.
+
 -   Few seismologists have strong expertise in modern information technology.
     Furthermore, installing a software package can prove challenging today
     on a desktop on which you may have special privileges.  On large hypocenter
@@ -18,16 +23,19 @@ We begin with some key features of MsPASS.
     modern container technology to simplify installation.  That allows you
     as the user to install MsPASS without system privileges.  Containers are
     also essential for operating the package in a cloud system.
--   Another keyword in the acronymn is "parallel".  Computer technology reached
+
+-   Another keyword in the acronym is "parallel".  Computer technology reached
     the physical limit of single CPU computers many years ago.  NO existing
     package for handling earthquake data provides consistent support for
     parallel processing.
+
 -   A first order goal of MsPASS was building
     a consistent framework to allow scalability from a single desktop
     machine with multiple cores to a giant cloud-based system. In MsPASS
-    we developed a simplfied API for running processing in parallel.
+    we developed a simplified API for running processing in parallel.
     The API makes it relatively easy to prototype a workflow with a test data set before
     porting it to a large cluster to handle a more massive processing job.
+
 -   MsPASS uses an integrated database management system that
     was known previously to perform well in a massively parallel environment.
     We use a stable, open-source system called MongoDB.  Our database api
@@ -37,6 +45,7 @@ We begin with some key features of MsPASS.
     extensive documentation and tutorials are available online.  Web
     searches for MongoDB commands or a book at your side are an essential tool for
     working with MsPASS at any level.
+
 -   MsPASS uses python as the job control language.  This is in contrast to
     traditional programs like SAC or older seismic processing systems that
     use a custom command interpreter.   We assert that custom languages
@@ -44,6 +53,7 @@ We begin with some key features of MsPASS.
     Latin as a language in the coming years.  Python has emerged as the
     most common glue language use within software packages.  It was thus
     the clear choice as the driver language for MsPASS.
+
 -   Although python has huge advantages as "glue language" and as a way to
     quickly develop prototypes, it also has a serious limitation.   Python,
     like matlab's command line language, is an interpreted language.  That means
@@ -51,20 +61,21 @@ We begin with some key features of MsPASS.
     will run orders of magnitude faster if implemented in a compiled language
     like C/C++ or FORTRAN compared to python.  For this reason, we implemented
     core data objects in C++.  Any python package with any hope of
-    performance follows this same model.  `Obspy<https://docs.obspy.org/>`__
+    performance follows this same model.  `Obspy <https://docs.obspy.org/>`__
     does this by manipulating
     sample data with numpy and some core C libraries.
-    `Antelope<https://www.brtt.com>`__ python
+    `Antelope <https://www.brtt.com>`__ python
     does this as well by implementing core functions in C. We follow this
     model.  Python functions and classes implemented in C/C++ the MsPASS
     module hierarchy under mspasspy.ccore.
+
 -   Errors are a universal issue in large scale data processing.   As the
     size of a data set increases it is becomes a increasingly difficult to
     guarantee all the data are "clean".  By that, we mean one or more
     algorithms may treat "the problem" as an unrecoverable error.  Handling
     errors in a large scale processing environment is problematic for a long
     list of reasons.  We solve this in MsPASS by having error logs be an
-    intrisic part of the data.   In addition,
+    intrinsic part of the data.   In addition,
     following a well established approach
     used is seismic reflection systems since the 1960s MsPASS provides a
     integrated "kill" mechanism that allows data to be carried along
@@ -72,6 +83,7 @@ We begin with some key features of MsPASS.
     because dead data are treated like live data but they just process faster.
     The error messages posted to any data are automatically saved in the
     database when the data object is saved.
+
 -   To promote reproducible science MsPASS has an integrated processing history
     capability.  The goal of that component of MsPASS is to ultimately allow
     publication of the processing workflow used in a scientific paper that
@@ -80,13 +92,14 @@ We begin with some key features of MsPASS.
     For that reason (and for efficiency) MsPASS processing functions make
     handling history optional and by default it is turned off.  If the system
     grows as we hope that limitation may disappear.
+
 -   The design of MsPASS has stressed leading edge but not bleeding edge open-source
     technologies.  MsPASS was assembled from
     a long list of general purpose, open-source packages.
     Some are C/C++ libraries that
-    are linked with code in the ccore modules (e.g. `boost<https://www.boost.org/>`__
-    and the `GNU Scientific library<https://www.gnu.org/software/gsl/>`__)
-    and some are python packages like obspy.
+    are linked with code in the ccore modules (e.g. `boost <https://www.boost.org/>`__
+    and the `GNU Scientific Library <https://www.gnu.org/software/gsl/>`__)
+    and some are python packages like ObsPy.
 
 Getting Started
 ~~~~~~~~~~~~~~~~~~~
@@ -98,7 +111,7 @@ for installation instructions.  (CHANGE ME - POINTS NOW TO WIKI PAGE BUT
 WE NEED A REAL INSTALLATION PAGE)
 
 We have an extensive set of tutorials based on jupyter notebooks
-found `here<>`___ (DEAD LINK - ADD when we have a final location for tutorials).
+found `here <https://github.com/wangyinz/mspass_tutorial>`__.
 For most people these are a good way to learn the package on their own.
 
 Organization of User Manual

--- a/docs/source/user_manual/introduction.rst
+++ b/docs/source/user_manual/introduction.rst
@@ -1,0 +1,112 @@
+Introduction
+=================================
+MsPASS Features
+~~~~~~~~~~~~~~~~
+MsPASS is an acronymn that comes from Massively Parallel Analysis System for Seismologists.
+We begin with some key features of MsPASS.
+
+-   As the name suggests MsPASS is a domain-specific package for seismologists.
+    We emphasize, however, that our definition of seismologists is
+    broad.  It includes exploration geophysicists and anyone in any field that
+    needs to work with data that match the data models described in this
+    manual.
+-   Few seismologists have strong expertise in modern information technology.
+    Furthermore, installing a software package can prove challenging today
+    on a desktop on which you may have special privileges.  On large hypocenter
+    systems installation is usually impossible without a long string of
+    meetings and correspondence with system managers.  For this reason MsPASS uses
+    modern container technology to simplify installation.  That allows you
+    as the user to install MsPASS without system privileges.  Containers are
+    also essential for operating the package in a cloud system.
+-   Another keyword in the acronymn is "parallel".  Computer technology reached
+    the physical limit of single CPU computers many years ago.  NO existing
+    package for handling earthquake data provides consistent support for
+    parallel processing.
+-   A first order goal of MsPASS was building
+    a consistent framework to allow scalability from a single desktop
+    machine with multiple cores to a giant cloud-based system. In MsPASS
+    we developed a simplfied API for running processing in parallel.
+    The API makes it relatively easy to prototype a workflow with a test data set before
+    porting it to a large cluster to handle a more massive processing job.
+-   MsPASS uses an integrated database management system that
+    was known previously to perform well in a massively parallel environment.
+    We use a stable, open-source system called MongoDB.  Our database api
+    aims to abstract interactions with MongoDB as much as possible, but
+    some knowledge of the query language used by MongoDB will be required to
+    use the package effectively.  There are several published books and
+    extensive documentation and tutorials are available online.  Web
+    searches for MongoDB commands or a book at your side are an essential tool for
+    working with MsPASS at any level.
+-   MsPASS uses python as the job control language.  This is in contrast to
+    traditional programs like SAC or older seismic processing systems that
+    use a custom command interpreter.   We assert that custom languages
+    like that in SAC or even the unix shell will become the equivalent of
+    Latin as a language in the coming years.  Python has emerged as the
+    most common glue language use within software packages.  It was thus
+    the clear choice as the driver language for MsPASS.
+-   Although python has huge advantages as "glue language" and as a way to
+    quickly develop prototypes, it also has a serious limitation.   Python,
+    like matlab's command line language, is an interpreted language.  That means
+    it is essentially compiled on the fly.  Some classes of algorithms
+    will run orders of magnitude faster if implemented in a compiled language
+    like C/C++ or FORTRAN compared to python.  For this reason, we implemented
+    core data objects in C++.  Any python package with any hope of
+    performance follows this same model.  `Obspy<https://docs.obspy.org/>`__
+    does this by manipulating
+    sample data with numpy and some core C libraries.
+    `Antelope<https://www.brtt.com>`__ python
+    does this as well by implementing core functions in C. We follow this
+    model.  Python functions and classes implemented in C/C++ the MsPASS
+    module hierarchy under mspasspy.ccore.
+-   Errors are a universal issue in large scale data processing.   As the
+    size of a data set increases it is becomes a increasingly difficult to
+    guarantee all the data are "clean".  By that, we mean one or more
+    algorithms may treat "the problem" as an unrecoverable error.  Handling
+    errors in a large scale processing environment is problematic for a long
+    list of reasons.  We solve this in MsPASS by having error logs be an
+    intrisic part of the data.   In addition,
+    following a well established approach
+    used is seismic reflection systems since the 1960s MsPASS provides a
+    integrated "kill" mechanism that allows data to be carried along
+    but ignored.  That model maps well to massively parallel scheduling
+    because dead data are treated like live data but they just process faster.
+    The error messages posted to any data are automatically saved in the
+    database when the data object is saved.
+-   To promote reproducible science MsPASS has an integrated processing history
+    capability.  The goal of that component of MsPASS is to ultimately allow
+    publication of the processing workflow used in a scientific paper that
+    would allow the reader to reproduce the data that paper used.  At the
+    time this user's manuals was written that part of the system is incomplete.
+    For that reason (and for efficiency) MsPASS processing functions make
+    handling history optional and by default it is turned off.  If the system
+    grows as we hope that limitation may disappear.
+-   The design of MsPASS has stressed leading edge but not bleeding edge open-source
+    technologies.  MsPASS was assembled from
+    a long list of general purpose, open-source packages.
+    Some are C/C++ libraries that
+    are linked with code in the ccore modules (e.g. `boost<https://www.boost.org/>`__
+    and the `GNU Scientific library<https://www.gnu.org/software/gsl/>`__)
+    and some are python packages like obspy.
+
+Getting Started
+~~~~~~~~~~~~~~~~~~~
+
+The first step to use MsPASS is to install a local copy that you can use
+for initial experimentation.
+`Click here <https://github.com/wangyinz/mspass/wiki/Using-MsPASS-with-Docker>`__
+for installation instructions.  (CHANGE ME - POINTS NOW TO WIKI PAGE BUT
+WE NEED A REAL INSTALLATION PAGE)
+
+We have an extensive set of tutorials based on jupyter notebooks
+found `here<>`___ (DEAD LINK - ADD when we have a final location for tutorials).
+For most people these are a good way to learn the package on their own.
+
+Organization of User Manual
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The titles of the sections of this manual should serve as guides for
+how to learn more about a topic of interest.   Except for this section the
+manual is not intended to be read in the order of the topics posted as
+hypertext in the contents page.  A learning model most people find most
+effective is to work through the tutorials and reading sections of this
+manual as questions arise or by following hypertext links from the tutorials.


### PR DESCRIPTION
The only changes in this branch from the origin pulled only moments ago is the addition of two new rst documents in source:  an introduction document and a section on error handling.  I did not edit the index html as I'm not sure how that is handled in the sphynx setup.  This should merge clean.  The rst file previews fine for me.  Only question is if you need some special formatting commands to mesh with sphynx.