### PR TITLE
Add new dbverify command line tool and related python module verify

### DIFF
--- a/docs/source/man/man1/dbverify.1
+++ b/docs/source/man/man1/dbverify.1
@@ -1,0 +1,173 @@
+'\" te
+.TH DBVERIFY 1
+#
+.SH NAME
+dbverify - MsPASS database verify command line tool
+.SH SYNOPSIS
+.nf
+dbverify dbname [-t testname] [-c col ... ]
+         [-n n1 ...] [-r k1 ...][-e n] [-v] [-h | --help]
+.fi
+.SH DESCRIPTION
+.LP
+\fIdbverify\fR is a command line tool to run a set of essential tests on
+a dataset stored in the MsPASS database.   This program or the test
+functions it uses should always be run on a dataset before starting
+a long job to process data with MsPASS.  It performs essential validation
+tests that are needed to reduce the chances of a large workflow aborting
+during processing.  The command line tool, \fIdbverify\fR, should be viewed as a
+front-end to test functions in the python library of MsPASS.  This tool
+was written largely to provide a way simply the output of the test
+functions and produce output that can be more easily understood. Note the
+tool was intentionally designed to run only one test at a time to
+simplify output.  Because MongoDB supports many simultaneous clients to
+test large data sets it may be useful to run each test as a separate job.
+
+The following tests are currently supported.
+They can only be run one at a time and are controlled by the \fItestname\fR
+argument attached to the -t flag:
+.IP (1)
+\fInormalization\fR:  This test validates cross-references to collections that
+MongoDB calls normalized data.  Normalized data are smaller collections of
+common data that are more efficient to store together and link to the
+waveform data through a query with a cross-referencing key.   In MsPASS
+current normalization collections in the standard schema are called
+\fIsite, channel\fR, and \fIsource\fR.  When this test is run the -n
+option can be used to control what normalization collections are tested.
+The default is equivalent to "-n site".   The collection on which the
+test is to be run can be set with the -c option.  For this test -c should
+reference either wf_TimeSeries or wf_Seismogram.  It can only be run on
+one collection at a time.
+.IP (2)
+\fIrequired\fR:   Certain attributes are always required for processing.
+Use the -r option to provide a list of keys that should be
+checked for existence in the specified collection.   If -r is not give
+an internal default is used.   We recommend always providing a list of
+what your workflow considers required.  Only one collection can be
+processed at a time to keep the -r list manageable.
+.IP (3)
+\fIschema_check\fR:   Although MongoDB is completely promiscuous about
+types of attributes associated with any key, in MsPASS we imposed some order on the
+system through a schema.   Some attributes can have type requirements that
+may cause a job to abort if they are improperly defined.  The idea of this
+test is to flag all possible key-value pairs in a collection that
+are inconsistent with the schema.  Some mismatches are mostly harmless
+while others are nearly guaranteed to cause processing problems.
+What defines "mostly harmless" is discussed in more detail below in the
+section titled "Interpreting Test Results".   This is currently the only
+test that can be run on multiple collections in a single run.   The reason
+is it depends completely on the schema and needs no other direction
+other than a list of collections to scan.
+
+.SH ARGUMENTS
+.LP
+Argument 1 is require to be a valid database name.   The program will attempt
+to connect the MongoDB server and access the data with that name tag.  The
+program will abort immediately if MongoDB is not running.   If you give an
+invalid name you can expect mysterious errors - most likely complaints that
+the collection you tried to test has no data.
+.IP -t
+Control the testname as described above.  Can also use --test.
+.IP -c
+This flag is used to mark the list of one or more collections.  Only the
+\fIschema_check\fR test supports multiple collections in one run. The other tests have
+argument dependencies that do not map well to the command line argument
+method of control parameter inputs.  For those tests if multiple arguments
+follow -c only the first will be used and a warning error will be printed.
+Can also use --collection as this flag.
+.IP -n
+This is used to mark the start of a list of secondary collections to that
+defined by -c that are expected to resolve with cross reference ids
+in the \fInormalization\fR test.   Any -n arguments for
+tests other than \fInormalization\fR will be ignored.  Can also use --normalize.
+.IP -r
+This is used to mark a list of required key attributes for the \frequired\fR
+test.   Any arguments after -r will be ignored by other tests.
+Can also use --required.
+.IP -v
+Runs in verbose mode.  Default is to print only a summary of the test results.
+Verbose mode is most useful as a followup when errors are detected in one
+or more collections and you need more information about what is wrong.
+Can also use --verbose
+.IP -e
+Sets a limit on the number of errors found before stopping the test.
+A large dataset with a common error in most or all the documents in
+a collection can generate voluminous output in verbose mode and pass the
+point of diminishing returns for the standard summary mode. The default is
+1000.  Smaller numbers are often useful in verbose mode and larger numbers
+may be needed for data sets assembled from multiple sources with different
+problems.
+.SH EXAMPLES
+.nf
+# Run the normalization test on the wf_Seismogram collection:
+dbverify mydb -c wf_Seismogram -t normalization -n site source
+# Run the required test on the channel collection
+dbverify mydb -c channel -t required -r lat lon elev hang vang starttime endtime
+# Run the schema_check test on all standard collections fpr TimeSeries data
+dbverify mydb -c wf_TimeSeries channel source -t schema_check
+# Rerun schema test on wf_TimeSeries to clarify errors
+# impose a limit of only 100 documents to keep the output reasonable.
+dbverify mydb -c wf_TimeSeries -t schema_check -v -e 100
+.fi
+.SH INTERPRETING TEST RESULTS
+We recommend this program should usually be run in the default nonverbose mode.
+In that mode all the tests attempt to simply summarize the errors the test
+found.  In most cases that is list of offending keys and the number of documents
+found with the particular error.
+
+The \fInormalization\fR test print an all is well message if it finds
+no errors for a given collection.  If there are problems it will simply
+list the number of documents it found with an error.  If that number is
+the same as the error limit or the number of waveforms in the database it
+probably means all links to that collection are broken.
+
+In normal mode the \fIschema_check\fR and \fIrequired\fR test both produce
+an output of offending keys and the number of documents they found with
+that error.  The types of errors are defined in the print statements.
+
+In all cases, the way you should use this program is to first always run
+it in the default (not verbose) mode.  If any of the test fail look
+at the output carefully.  Some errors may not require rerunning the
+program.  For example, keys that are not defined in the schema will
+generate errors in multiple tests. Undefined keys are usually harmless
+but they do waste storage if they aren't really needed.  Type collisions
+can be the hardest to sort out.  If you have type mismatch errors
+we recommend the first step is to rerun the same test in verbose mode
+to look at the full set of attributes stored in the offending collection
+for a few errors.  As noted earlier when running in verbose mode it is
+usually prudent to reduce the error limit size with the -e option.
+Many type errors are recoverable and some are not.  For example, it is
+relatively easy in python to unintentionally post a real number as an integer.
+That is particularly so when data are entered as literals in a python script.
+(e.g. in python the statements x=11.0 and y=11 do not the same things even though
+the numbers might seem the same.  x is a float and y is an integer.)
+The MsPASS readers will convert type collisions like the example above
+automatically.  What is not repairable are string data appearing in a field
+the schema requires to be a number.  e.g. if one posted lat='37N22.40' it might
+look right but cannot be automatically converted.  The point is type
+mismatches can be hard to detect without this tool and even after it is
+detected it can be a challenge to see the problem from the output.
+Fortunately, such errors are rare unless a function has a bug or the input
+is created by some simulation method that doesn't set some attributes
+correctly. 
+
+.SH "SEE ALSO"
+.LP
+The tests this program runs are python functions found in the module
+mspasspy.db.verify.   See the sphynx documentation for more about
+the individual functions.
+.SH "BUGS AND CAVEATS"
+.LP
+The function currently does not support any query mechanism on a
+collection it processes.  It will only work on an entire collection or
+set of collections you direct the program to process.  All the current
+tests are reasonably fast and should be feasible as a serial process
+for any currently conceivable dataset, but for very large data sets
+some of them could take some time to complete.   If you need to
+query a smaller data volume use the python functions directly.
+.SH AUTHOR
+.nf
+Gary L. Pavlis
+Department of Earth and Atmospheric Sciences
+Indiana University
+.fi

--- a/python/mspasspy/db/editing.py
+++ b/python/mspasspy/db/editing.py
@@ -1,0 +1,164 @@
+def delete_attributes(db,collection,keylist,query={},verbose=False):
+    """
+    Deletes all occurrences of attributes linked to keys defined 
+    in a list of keywords passed as (required) keylist argument.  
+    If a key is not in a given document no action is taken. 
+    
+    :param db:  Database handle to be updated
+    :param collection:  MongoDB collection to be updated
+    :param keylist:  list of keys for elements of each document 
+      that are to be deleted.   key are not test against schema 
+      but all matches will be deleted.
+    :param query: optional query string passed to find database 
+      collection method.  Can be used to limit edits to documents 
+      matching the query.  Default is the entire collection.
+    :param verbose:  when true edit will produce a line of printed 
+      output describing what was deleted.  Use this option only if 
+      you know from dbverify the number of changes to be made are small.
+      
+    :return:  dict keyed by the keys of all deleted entries.  The value 
+      of each entry is the number of documents the key was deleted from.
+    """
+    dbcol=db[collection]
+    cursor=dbcol.find(query)
+    counts=dict()
+    # preload counts to 0 so we get a return saying 0 when no changes 
+    # are made
+    for k in keylist:
+        counts[k]=0
+    for doc in cursor:
+        id=doc.pop('_id')
+        n=0
+        todel=dict()
+        for k in keylist:
+            if k in doc:
+                todel[k]=doc[k]
+                val=doc.pop(k)
+                if verbose:
+                    print('Deleted ',val,' with key=',k,' from doc with id=',id)
+                counts[k]+=1
+                n+=1
+        if n>0:
+            dbcol.update_one({'_id':id},{'$unset' : todel})
+    return counts
+    
+def rename_attributes(db,collection,rename_map,query={},verbose=False):
+    """
+    Renames specified keys for all or a subset of documents in a 
+    MongoDB collection.   The updates are driven by an input python 
+    dict passed as the rename_map argument. The keys of rename_map define
+    doc keys that should be changed.  The values of the key-value 
+    pairs in rename_map are the new keys assigned to each match.  
+    
+    
+    :param db:  Database handle to be updated
+    :param collection:  MongoDB collection to be updated
+    :param rename_map:  remap definition dict used as described above.
+    :param query: optional query string passed to find database 
+      collection method.  Can be used to limit edits to documents 
+      matching the query.  Default is the entire collection.
+    :param verbose:  when true edit will produce a line of printed 
+      output describing what was deleted.  Use this option only if 
+      you know from dbverify the number of changes to be made are small.
+      When false the function runs silently.
+      
+    :return:  dict keyed by the keys of all changed entries.  The value 
+      of each entry is the number of documents changed.  The keys are the 
+      original keys.  displays of result should old and new keys using 
+      the rename_map.
+    """
+    dbcol=db[collection]
+    cursor=dbcol.find(query)
+    counts=dict()
+    # preload counts to 0 so we get a return saying 0 when no changes 
+    # are made
+    for k in rename_map:
+        counts[k]=0
+    for doc in cursor:
+        id=doc.pop('_id')
+        n=0
+        for k in rename_map:
+            n=0
+            if k in doc:
+                val=doc.pop(k)
+                newkey=rename_map[k]
+                if verbose:
+                    print('Document id=',id)
+                    print('Changed attribute with key=',k,' to have new key=',newkey)
+                    print('Attribute value=',val)
+                doc[newkey]=val
+                counts[k]+=1
+                n+=1
+        dbcol.replace_one({'_id':id},doc)
+    return counts
+def fix_attribute_types(db,collection,query={},verbose=False):
+    """
+    This function attempts to fix type collisions in the schema defined 
+    for the specified database and collection.  It tries to fix any 
+    type mismatch that can be repaired by the python equivalent of a 
+    type cast (an obscure syntax that can be seen in the actual code).  
+    Known examples are it can cleanly convert something like an int to 
+    a float or vice-versa, but it cannot do something like convert an 
+    alpha string to a number. Note, however, that python does cleanly 
+    convert simple number strings to number.  For example:  x=int('10')
+    will yield an "int" class number of 10.  x=int('foo'), however, will
+    not work.   Impossible conversions will not abort the function but 
+    will generate an error message printed to stdout.  The function 
+    continues on so if there are a large number of such errors the 
+    output could become voluminous.  ALWAYS run dbverify before trying 
+    this function (directly or indirectly through the command line 
+    tool dbclean).   
+    
+    :param db:  Database handle to be updated
+    :param collection:  MongoDB collection to be updated
+    :param query: optional query string passed to find database 
+      collection method.  Can be used to limit edits to documents 
+      matching the query.  Default is the entire collection.
+    :param verbose:  when true edit will produce one or more lines of 
+      printed output for each change it makes.  The default is false.
+      Needless verbose should be avoided unless you are certain the 
+      number of changes it will make are small.  
+    """
+    dbcol=db[collection]
+    schema=db.database_schema
+    col_schema=schema[collection]
+    counts=dict()
+    cursor=dbcol.find(query)
+    for doc in cursor:
+        n=0
+        id=doc.pop('_id')
+        if verbose:
+            print("////////Document id=",id,'/////////')
+        up_d=dict()
+        for k in doc:
+            val=doc[k]
+            if not col_schema.is_defined(k):
+                if verbose:
+                    print('Warning:  in doc with id=',id,
+                          'found key=',k,' that is not defined in the schema')
+                    print('Value of key-value pair=',val)
+                    print('Cannot check type for an unknown attribute name')
+                continue
+            if not isinstance(val,col_schema.type(k)):
+                try:
+                    newval=col_schema.type(k)(val)
+                    up_d[k]=newval
+                    if verbose:
+                        print('Changed data for key=',k,' from ',val,' to ',newval)
+                    if k in counts:
+                        counts[k]+=1
+                    else:
+                        counts[k]=1
+                    n+=1
+                except Exception as err:
+                    print("////////Document id=",id,'/////////')
+                    print('WARNING:  could not convert attribute with key=',
+                          k,' and value=',val,' to required type=',
+                          col_schema.type(k))
+                    print('This error was thrown and handled:  ')
+                    print(err)
+         
+        if n>0:
+            dbcol.update_one({'_id' : id},{'$set' : up_d})
+            
+    return counts

--- a/python/mspasspy/db/script/dbclean
+++ b/python/mspasspy/db/script/dbclean
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This file contains a python script that defines a command line 
+tool we call dbclean.  dbclean is designed to fix errors detected
+with a companion command line tool called dbverify.  The options 
+of this tool largely map into errors or potential errors detected by 
+dbverify.  
+
+"""
+import argparse
+from bson import json_util
+from mspasspy.db.database import Database
+from mspasspy.db.client import Client as DBClient
+from mspasspy.db.editing import (delete_attributes,
+                                 rename_attributes,
+                                 fix_attribute_types)
+
+
+def rename_list_to_dict(rlist):
+    """
+    Helper for main to parse args for rename operator.  The args are 
+    assumed to be a pair of strings separated by a ":".  These are 
+    parsed into a dict that is returned with the old document key to 
+    be replaced as the (returned) dict key and the value of the return 
+    being set as the string defining the new key.  
+
+    """
+    result=dict()
+    for val in rlist:
+        pair=val.split(':')
+        if len(pair)!=2:
+            print('Cannot parse pair defined as ',val)
+            print('-r args are expected to be pairs of keys strings with a : separator')
+            print('Type dbclean --help for usage details')
+            exit(-1)
+        result[pair[0]]=pair[1]
+    return result
+        
+
+def main():
+    """
+    """
+    parser = argparse.ArgumentParser(prog="dbclean",
+                                     usage="%(prog)s dbname collection [-ft] [-d k1 ...] [-r kold:knew ... ] [-v] [-h]",
+                                     description="MsPASS program to fix most errors detected by dbverify")
+    parser.add_argument('dbname',
+                        metavar='dbname',
+                        type=str,
+                        help='MongoDB database name to be fixed')
+    parser.add_argument('collection',
+                        metavar='collection',
+                        type=str,
+                        help='MongoDB collection name to be fixed')
+    parser.add_argument('-ft',
+                        '--fixtypes',
+                        action='store_true',
+                        help='Enable automatic type mismatch repair'
+                        )
+    parser.add_argument('-d',
+                        '--delete',
+                        nargs='*',
+                        default=[],
+                        help='List of keys of key-value pairs to be deleted from all documents'
+                        )
+    parser.add_argument('-r',
+                        '--rename',
+                        nargs='*',
+                        default=[],
+                        help='Change the keys of documents using pattern defined in args of form oldkey:newkey'
+                        )
+    parser.add_argument('-v',
+                        '--verbose',
+                        action='store_true',
+                        help='When used be echo each fix - default works silently'
+                        )
+    
+    args = parser.parse_args()
+    dbname=args.dbname
+    collection=args.collection
+    fixtypes=args.fixtypes
+    delete=args.delete
+    rename=args.rename
+    verbose=args.verbose
+    
+    
+    # not a very robust way to detect this condition but it should work
+    # it is not robust because it assumes a behavior in argparse for 
+    # args with a list
+    if len(delete)>0:
+        enable_deletion=True 
+    else:
+        enable_deletion=False
+    if len(rename)>0:
+        enable_rename=True
+    else:
+        enable_rename=False
+    if not(fixtypes or enable_deletion or enable_rename):
+        print('Usage error:  you must define at least one clean operation')
+        print('Type:  dbclean --help to get usage help')
+        exit(-1)
+        
+    if enable_rename:
+        rename_map=rename_list_to_dict(rename)
+        
+    dbclient=DBClient()
+    db=Database(dbclient,dbname)
+    print('Starting processing of ',collection,
+          ' collection of database named=',dbname)
+    
+    # Intentionally do the delete and rename operations before 
+    # a type check to allow cleaning any keys. The set of dicts below 
+    # accumulate counts of edits for each key
+    
+    if enable_deletion:
+        delcounts=delete_attributes(db,collection,delete,verbose=verbose)
+        print('delete processing compeleted on collection=',collection)
+        print('Number of documents changed for each key requested follow:')
+        print(json_util.dumps(delcounts,indent=4))
+    if enable_rename:
+        repcounts=rename_attributes(db,collection,rename_map,verbose=verbose)
+        print('rename processing compeleted on collection=',collection)
+        print('Here is the set of changes requested:')
+        print(json_util.dumps(rename_map))
+        print('Number of documents changed for each key requested follow:')
+        print(json_util.dumps(repcounts,indent=4))
+    if fixtypes:
+        fixcounts=fix_attribute_types(db,collection,verbose=verbose)
+        print('fixtype processing compeleted on collection=',collection)
+        print('Keys of documents changed and number changed follow:')
+        print(json_util.dumps(fixcounts,indent=4))
+
+if __name__ == "__main__":
+    main()

--- a/python/mspasspy/db/script/dbverify
+++ b/python/mspasspy/db/script/dbverify
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+This is a command line interface to run some standard tests on 
+a MsPASS database stored in MongoDB.   Run the command with the 
+--help option to see standard usage.   A detailed man page is 
+is found in the docs.
+"""
+
+import argparse
+from bson import json_util
+from bson.objectid import ObjectId
+import mspasspy.db.database.verify
+from mspasspy.ccore.utility import MsPASSError
+from mspasspy.db.database import Database
+from mspasspy.db.client import Client as DBClient
+
+def print_id_keyed_dict(d):
+    """
+    Prints a python dict d keyed by ObjectId in a format with 
+    beginning and end of each dump marked by an obvious human readable 
+    mark.   Part of the reason this is necesary is json_util.dumps like
+    json.dumps does not like dict keys to be anything but a simple type.
+    
+    :param d:  python dict with id keys to be printed
+    """
+    newdoc_string="=========================================================="
+    for key,value in d.items():
+        print(newdoc_string)
+        if isinstance(key,ObjectId):
+            print('ObjectId string of document=',str(key))
+        else:
+            print('WARNING:  key is not object id as it shoudl be. It is->',
+                  key,' of type ',type(key))
+        print(newdoc_string)
+        if type(value)==dict:
+            print(json_util.dumps(value,indent=2))
+        else:
+            print(value)
+    
+def print_bad_wf_docs(dbcol,idlist):
+    """
+    Print values from a doc defined in dbcol matching a list of ids.  
+    Print is the dump of the dict form from the aux_list subset.   
+    
+    :param dbcol:  database collection ids with errors were pulled from
+    :param idlist:  python list of ObjectIds to print
+
+    """
+    n=1
+    for id in idlist:
+        print('////////////////Doc number ',n,' with error///////////////')
+        query={'_id' : id}
+        doc=dbcol.find_one(query)
+        print(json_util.dumps(doc,indent=2))
+        print('////////////////////////////////////////////////////////')
+                
+def run_check_links(db,wfcollection,nrmlist,elimit,verbose):
+    """
+    Run the verify function called check_links and produces a reasonable
+    summary or readable (verbose) printed output of the results.  
+    The check_links function verifies if normalization ids are 
+    set and resolve correctly.   It treats the two problems together
+    but returns containers that link to each problem separately.  
+    This function prints a summary of the result of the function 
+    when not verbose.  When verbose a json dump of all attributes
+    in offending documetions are written to stdout - this can get 
+    quite huge but use the elimit arg to reduce the size.
+    
+    :param db:  mspass Database handle
+    :param wfcollection:  waveform collection name to be scanned for 
+      normalization links.
+    :param nrmlist:  is a list of collection names that are to 
+      be tested.  Note in MsPASS we assume the cross reference is an
+      ObjectId of the document in a give collection name. e.g. for 
+      a link to site the test will search for site_id and verify 
+      a document with that id is in site.  
+    :param elimit:  number of errors allowed before the test is 
+      terminated. For large data sets with many problems this test
+      could take a long time just to return a summary.  Keep this 
+      parameter small until you find common errors to reduce effort.
+    :verbose:  when true each document with an error will have the 
+      entire contents (sans waveform sample data) printed. When
+      false (the default for this program) only print a summary of 
+      how many offending docs were found.  
+
+    """
+
+    for nrmcol in nrmlist:
+        errs=verify.check_links(db,normalize=nrmcol,
+                          wf=wfcollection,
+                          error_limit=elimit)
+        broken=errs[0]
+        undef=errs[1]
+        if verbose:
+            if len(broken)==0:
+                print('check_links found no broken links with collection=',nrmcol)
+            else:
+                print('check_link found the following docs in ',wfcollection,
+                  ' with broken links to ',nrmcol)
+                print_bad_wf_docs(db,broken)
+            if len(undef)==0:
+                print('check_links found no undefined linking key to collection=',
+                  nrmcol)
+            else:
+                print('check_link found the following docs in ',wfcollection,
+                  ' with undefined link keys to ',nrmcol)
+                print_bad_wf_docs(db,undef)
+        else:
+            if len(broken)==0:
+                print('check_links found no broken links with collection=',nrmcol)
+            else:
+                print('normalization test on collection=',nrmcol,' found problems')
+                print('Found broken links in ',len(broken),
+                      'documents checked')
+                print('Note error count limit=',elimit)
+                print('If the count is the same it means all data probably contain missing cross referencing ids')
+                print('Run in verbose mode to find out more information you will need to fix the problem')
+            
+def run_check_attribute_types(db,col,elimit,verbose):
+    """
+    Run the verify function called check_attribute_types and produces 
+    a reasonable summary or readable (verbose) printed output of the results.  
+    The function checks for schema collisions of two types:  (1) type
+    mismatch of what what the schema asks and what is actually found 
+    and (2) data with keys not found in the schema definition. 
+    It treats the two problems together
+    but returns containers that link to each problem separately.  
+    This function prints a summary of the result of the function 
+    when not verbose.  When verbose a json dump of all attributes
+    in offending documetions are written to stdout - this can get 
+    quite huge but use the elimit arg to reduce the size.
+    
+    :param db:  mspass Database handle
+    :param collection:  collection name to be scanned.  
+    :param elimit:  number of errors allowed before the test is 
+      terminated. For large data sets with many problems this test
+      could take a long time just to return a summary.  Keep this 
+      parameter small until you find common errors to reduce effort.
+    :verbose:  when false (default for this program) only a summary 
+      of offending keys and counts of the number of problems found 
+      are printed. When true every document with offending data will
+      be printed with the values (most useful for type mismatch errors)
+
+    """
+    # Although the function allows it this program won't support
+    # a query for now because it would get ugly with different 
+    # definitions for each collection listed.  Verbose is 
+    # also always off.  Note the solution to enter one from 
+    # an input is to use json.loads
+    errs=verify.check_attribute_types(db,col,error_limit=elimit)
+    mismatch=errs[0]
+    undef=errs[1]
+    print('check_attribute_types result for collection=',col)
+    if verbose: 
+        if len(mismatch)==0:
+            print('Collection has no type inconsistencies with schema')
+        else:
+            print('//////Collection=',col,' has type inconsistencies in ',
+                  len(mismatch),' documents////')
+            print('///The following have types that do not match schema////')
+            print_id_keyed_dict(mismatch)
+        if len(undef)==0:
+            print('Collection has no data with keys not defined in schema')
+        else:
+            print('//////Collection=',col,' has unrecogized keys in ',
+                  len(undef),' documents/////')
+            print('////The following are offending data with doc ids///')
+            print_id_keyed_dict(undef)
+    else:
+        if len(mismatch)==0:
+            print('Collection has no type inconsistencies with schema')
+        else:
+            mmkeys=dict()
+            for k in mismatch:
+                badkeys=mismatch[k]
+                for bad in badkeys:
+                    if bad in mmkeys:
+                        n=mmkeys[bad]
+                        n+=1
+                        mmkeys[bad]=n
+                    else:
+                        mmkeys[bad]=1
+            print('Collection found ',len(mismatch),
+                  ' documents with type inconsistencies')
+            print('Offending keys and number found follow:')
+            print(json_util.dumps(mmkeys,indent=2))
+        #Same for undef with minor differences in what is printed
+        # maybe should make this a function
+        if len(undef)==0:
+            print('Collection has no type inconsistencies with schema')
+        else:
+            mmkeys=dict()
+            for k in undef:
+                badkeys=undef[k]
+                for bad in badkeys:
+                    if bad in mmkeys:
+                        n=mmkeys[bad]
+                        n+=1
+                        mmkeys[bad]=n
+                    else:
+                        mmkeys[bad]=1
+            print('Collection found ',len(undef),
+                  ' documents with keys not defined in the schema')
+            print('Offending keys and number found follow:')
+            print(json_util.dumps(mmkeys,indent=2))
+
+                
+def run_check_required(db,col,required_list,elimit,verbose):
+    """
+    Each standard collection in mspass has some key attributes that
+    are essential to be useful.   This test should be run to verify 
+    critical data are defined before a major processing run.   This
+    function is a print wrapper for the test function check_required.  
+    The program default runs it with verbose false in which case it only 
+    prints a summary of offending keys and the number of documents 
+    found that were missing each required key.  When verbose is true
+    the contents of all offending documents will be printed in a 
+    readable layout with json_util.dumps.  
+
+    """
+    errs=verify.check_required(db,col,required_list,error_limit=elimit)
+    mismatch=errs[0]
+    undef=errs[1]
+    print('////Results from run_check_required on collection=',col)
+    if verbose:
+        if len(mismatch)==0:
+            print('Collection has no type mismatches')
+        else:
+            print('/////Collection has ',len(mismatch),
+              ' documents with a type mismatch//////')
+            print('/////Mismatched data with doc ids follow/////')
+            print_id_keyed_dict(mismatch)
+            print('//////////////////////////////////////////////////////////////')
+        if len(undef)==0:
+            print('Collection has all required data')
+        else:
+            print('Collection has at least ',len(undef),
+              ' documents lacking one or more attributes')
+            print('///////ids of bad docs with missing keys listed follow')
+            print_id_keyed_dict(undef)
+            print('//////////////////////////////////////////////////////////////')
+    else:
+        if len(mismatch)==0:
+            print('Collection has no type mismatches')
+        else:
+            mmkeys=dict()
+            for k in mismatch:
+                badkeys=undef[k]
+                for bad in badkeys:
+                    if bad in mmkeys:
+                        n=mmkeys[bad]
+                        n+=1
+                        mmkeys[bad]=n
+                    else:
+                        mmkeys[bad]=1
+            print('Collection found ',len(mismatch),
+                  ' documents with type inconsistencies')
+            print('Offending keys and number found follow:')
+            print(json_util.dumps(mmkeys,indent=2))
+        if len(undef)==0:
+            print('Collection has all required data')
+        else:
+            mmkeys=dict()
+            for k in undef:
+                badkeys=undef[k]
+                for bad in badkeys:
+                    if bad in mmkeys:
+                        n=mmkeys[bad]
+                        n+=1
+                        mmkeys[bad]=n
+                    else:
+                        mmkeys[bad]=1
+            print('Collection found ',len(undef),
+                  ' documents with required keys that were not defined')
+            print('Offending keys and number found follow:')
+            print(json_util.dumps(mmkeys,indent=2))
+
+def get_required(collection):
+    if collection=='site':
+        return ['lat','lon','elev'] 
+    elif collection=='channel':
+        return ['lat','lon','elev','hang','vang']
+    elif collection=='source':
+        return ['lat','lon','depth','time']
+    elif collection=='wf_TimeSeries' or collection=='wf_Seismogram':
+        return ['npts','delta','starttime']
+    else:
+        raise MsPASSError('No data on required attributes for collection='
+                          +collection,'Fatal')
+def main():
+    # As a script that would be run from the shell we let 
+    # any functions below that throw exception do so and assume they 
+    # will write a message that can help debug what went wrong
+    parser = argparse.ArgumentParser(prog="dbverify",
+                    usage="%(prog)s dbname [-t TEST -c [collection ...] -n [normalize ... ] -error_limit n -v]",
+                    description="MsPASS database verify program")
+    parser.add_argument('dbname',
+                       metavar='dbname',
+                       type=str,
+                       help='MongoDB database name on which to run tests')
+    parser.add_argument('-t',
+                        '--test',
+                        action='store',
+                        type=str,
+                        default='normalization',
+                        help='Select which test to run.  '
+                          + 'Current options:  normalization, required, schema_check'
+                          )
+    parser.add_argument('-c',
+                        '--collection',
+                        action='store',
+                        nargs='*',
+                        default=['wf_TimeSeries'],
+                        help='Collection(s) on which the test is to be run.  '
+                               + 'Only schema_check supports multiple collections in one run'
+                        )
+    parser.add_argument('-n',
+                       '--normalize',
+                       nargs='*',
+                       default=['site','channel','source'],
+                       help='List of normalization collections to test\n'
+                         + '(Used only for -test normalization option'
+                       )
+    parser.add_argument('-r',
+                        '--require',
+                        nargs='*',
+                        default=[],
+                        help='List of keys of required attributes for required test'
+                        )
+    parser.add_argument('-e',
+                        '--error_limit',
+                        action='store',
+                        type=int,
+                        default=1000,
+                        help='Set error limit - stop checking when this many errors are found\n'
+                        + 'Default is 1000'
+                        )
+    parser.add_argument('-v',
+                       '--verbose',
+                       action='store_true',
+                       help='When used print offending values.  Otherwise just return a summary'
+                       )
+
+    args = parser.parse_args()
+    test_to_run=args.test
+    dbname=args.dbname
+    dbclient=DBClient()
+    db=Database(dbclient,dbname)
+    col_to_test=args.collection
+    normalize=args.normalize
+    reqlist=args.require
+    verbose=args.verbose
+    elimit=args.error_limit
+
+    # If python had a switch case it would be used here.  this 
+    # is the list of known tests.  the program can only run one 
+    # test per execution.  Intentional to make output more readable
+    if test_to_run=='normalization':
+        if len(col_to_test)>1:
+            print('WARNING:  normalization test can only be run on one collection at a time')
+            print('Parsed a list with the following contents:  ',col_to_test)
+            print('Running test on the first item in that list')
+        col=col_to_test[0]
+        if not isinstance(col,str):
+            print('Invalid value parsed for -c option=',col)
+            exit(-1)
+        run_check_links(db,col,normalize,elimit,verbose)
+    elif test_to_run=='required':
+        if len(col_to_test)>1:
+            print('WARNING:  required test can only be run on one collection at a time')
+            print('Parsed a list with the following contents:  ',col_to_test)
+            print('Running test on the first item in that list')
+        col=col_to_test[0]
+        if not isinstance(col,str):
+            print('Invalid value parsed for -c option=',col_to_test)
+            exit(-1)
+        if len(reqlist)==0:
+            # Depends on default being an empty list. For default 
+            # case run this small function.
+            # This is currently a funtion above with const list values
+            # returned for each known collection.  It may eventually 
+            # be replaced a function using the schema
+            required_list=get_required(col)
+        else:
+            required_list=reqlist
+        run_check_required(db,col,required_list,elimit,verbose)
+    elif test_to_run=='schema_check':
+        for col in col_to_test:
+            run_check_attribute_types(db,col,elimit,verbose)
+    else:
+        print('Unrecognized value for --test value parsed=',test_to_run)
+        print('Must be one of:  normalization, required, or schema_check')
+    
+
+if __name__ == "__main__":
+    main()

--- a/python/mspasspy/db/verify.py
+++ b/python/mspasspy/db/verify.py
@@ -1,0 +1,300 @@
+from mspasspy.ccore.utility import MsPASSError
+"""
+This python module contains functions that will run a particular test on 
+a mongodb database collection in mspass.  The command line tool 
+dbverify is a front end to build more readable output from these
+functions.
+"""
+def check_links(db,normalize='site',
+                wf="wf_TimeSeries",
+                wfquery={},
+                verbose=False,
+                error_limit=1000):
+    """
+    This function checks for missing cross-referencing ids in a 
+    specified wf collection (i.e. wf_TimeSeries or wf_Seismogram)
+    It scans the wf collection to detect two potential errors:
+    (1) documents with the normalization key completely missing 
+    and (2) documents where the key is present does not match any 
+    document in normalization collection.   By default this
+    function operates silently assuming the caller will 
+    create a readable report from the return that defines 
+    the documents that had errors.  This function is used in the 
+    verify standalone program that acts as a front end to tests
+    in this module.  The function can be run in independently 
+    so there is a verbose option to print errors as they are encountered.
+    
+    :param db:  required MongoDB database handle.
+    :param wf:  mspass waveform collection on which the normalization
+      check is to be performed.  default is wf_TimeSeries.  
+      Currently only accepted alternative is wf_Seismogram.
+    :param wfquery:  optional dict passed as a query to limit the 
+      documents scanned by the function.   Default will process the 
+      entire wf collection.
+    :param verbose:  when True errors will be printed.  By default 
+      the function works silently and you should use the output to 
+      interact with any errors returned.  
+    :param error_limit: Is a sanity check on the number of errors logged.
+      Errors of any type are limited to this number (default 1000).
+      The idea is errors should be rare and if this number is exceeded 
+      you have a big problem you need to fix before scanning again.  
+      The number should be large enough to catch all condition but 
+      not so huge it become cumbersome.  With no limit or a memory 
+      fault is even possible on a huge dataset.
+    :return:  returns a tuple with two lists.  Both lists are ObjectIds
+      of the scanned wf collection that have errors.  component 0 
+      of the tuple contains ids of wf entries that have the normalization 
+      id set but the id does not resolve with the normalization collection.
+      component 1 contains the ids of documents in the wf collection that
+      do not contain the normalization id key at all (a more common problem)
+
+    """
+    # schema doesn't currently have a way to list normalized 
+    # collection names.  For now we just freeze the names 
+    # and put them in this one place for maintainability
+    norm_collection_list=['site','channel','source']
+    wf_collection_list=['wf_TimeSeries','wf_Seismogram']
+
+    if not (normalize in norm_collection_list):
+        raise MsPASSError('check_links:  illegal value for normalize arg='+normalize,
+                          'Fatal')
+    if not (wf in wf_collection_list):
+        raise MsPASSError('check_links:  illegal value for wf arg='+wf,
+                          'Fatal')
+    # this uses our convention - we need a standard method for to 
+    # define this key
+    idkey=normalize+'_id'
+    dbnorm=db[normalize]
+    dbwf=db[wf]
+    n=dbwf.count_documents(wfquery)
+    if n==0:
+        raise MsPASSError('checklinks:  '+wf
+            +' collection has no data matching query=',str(wfquery),
+            'Fatal')
+    if verbose:
+        print('Starting cross reference link check for ',wf,
+              ' collection using id=',idkey)
+        print('This should resolve links to ',normalize,' collection')
+    # We accumulate bad ids in this list that is returned
+    bad_id_list=list()
+    missing_id_list=list()
+    cursor=dbwf.find(wfquery)
+    for doc in cursor:
+        wfid=doc['_id']
+        if idkey in doc:
+            nrmid=doc[idkey]
+            n_nrm=dbnorm.count_documents({'_id' : nrmid})
+            if n_nrm==0:
+                bad_id_list.append(wfid)
+                if verbose:
+                    print(str(wfid),' link with ',str(nrmid),' failed')
+                if len(bad_id_list) > error_limit:
+                    raise MsPASSError('checklinks:  number of bad id errors exceeds internal limit',
+                                      'Fatal')
+        else:
+            missing_id_list.append(wfid)
+            if verbose:
+                print(str(wfid),' is missing required key=',idkey)
+            if len(missing_id_list) > error_limit:
+                    raise MsPASSError('checklinks:  number of missing id errors exceeds internal limit',
+                                      'Fatal')
+        if len(bad_id_list)>=error_limit or len(missing_id_list)>=error_limit:
+            break
+    return tuple([bad_id_list,missing_id_list])
+
+def check_attribute_types(db,
+                collection="wf_TimeSeries",
+                query={},
+                verbose=False,
+                error_limit=1000):
+    """
+    This function checks the integrity of all attributes 
+    found in a specfied collection.  It is designed to detect two 
+    kinds of problems:  (1) type mismatches between what is stored 
+    in the database and what is defined for the schema, and (2) 
+    data with a key that is not recognized.  Both tests are necessary 
+    because unlike a relational database MongoDB is very promiscuous 
+    about type and exactly what goes into a document.  MongoDB pretty 
+    much allow type it knows about to be associated with any key 
+    you choose.   In MsPASS we need to enforce some type restrictions 
+    to prevent C++ wrapped algorithms from aborting with type mismatches. 
+    Hence, it is important to run this test on all collections needed 
+    by a workflow before starting a large job.  
+    
+    :param db:  mspass Database handle.   Note this must be 
+      a Database class defined by "from mspasspy.db.database import Database".
+      The reason is that the mspass handle is an extension of MongoDB's 
+      handle that includes the Schema class used to run the tests in 
+      this function. This arg is required
+    :param collection:  MongoDB collection that is to be scanned 
+      for errors.  Note with normalized data this function should be 
+      run on the appropriate wf collection and all normalization 
+      collections the wf collection needs to link to. 
+    :param query:  optional dict passed as a query to limit the 
+      documents scanned by the function.   Default will process the 
+      entire collection requested.
+    :param verbose:  when True errors will be printed.   The default is
+      False and the function will do it's work silently.   Verbose is 
+      most useful in an interactive python session where the function 
+      is called directly.  Most users will run this function 
+      as part of tests driven by the dbverify program. 
+    :param error_limit: Is a sanity check the number of errors logged
+      The number of any type are limited to this number (default 1000).
+      The idea is errors should be rare and if this number is exceeded 
+      you have a big problem you need to fix before scanning again.  
+      The number should be large enough to catch all condition but 
+      not so huge it become cumbersome.  With no limit or a memory 
+      fault is even possible on a huge dataset.
+    :return:  returns a tuple with two python dict containers.  
+      The component 0 python dict contains details of type mismatch errors.
+      Component 1 contains details for data with undefined keys.  
+      Both python dict containers are keyed by the ObjectId of the 
+      document from which they were retrieved.  The values associated
+      with each entry are like MongoDB subdocuments.  That is, the value
+      return is itself a dict. The dict value contains key-value pairs
+      that defined the error (type mismatch for 0 and undefined for 1)
+
+    """
+    # The following two can throw MsPASS errors but we let them 
+    # do so. Callers should have a handler for MsPASSError
+    dbschema=db.database_schema
+    # This holds the schema for the collection to be scanned
+    # dbschema is mostly an index to one of these
+    col_schema=dbschema[collection]
+    dbcol=db[collection]
+    n=dbcol.count_documents(query)
+    if n == 0:
+        raise MsPASSError('check_attribute_types:  query='
+                          +str(query)+' yields zero matching documents',
+                          'Fatal')
+    cursor=dbcol.find(query)
+    bad_type_docs=dict()
+    undefined_key_docs=dict()
+    for doc in cursor:
+        bad_types=dict()
+        undefined_keys=dict()
+        id=doc['_id']
+        for k in doc:
+            if col_schema.is_defined(k):
+                val=doc[k]
+                if type(val)!=col_schema.type(k):
+                    bad_types[k]=doc[k]
+                    if(verbose):
+                        print('doc with id=',id,' type mismatch for key=',k)
+                        print('value=',doc[k],' does not match expected type=',
+                              col_schema.type(k))
+            else:
+                undefined_keys[k]=doc[k]
+                if(verbose):
+                    print('doc with id=',id,' has undefined key=',k,
+                          ' with value=',doc[k])
+        if len(bad_types)>0:
+            bad_type_docs[id]=bad_types
+        if len(undefined_keys)>0:
+            undefined_key_docs[id]=undefined_keys;
+        if len(undefined_key_docs)>=error_limit or len(bad_type_docs)>=error_limit:
+            break
+
+    return tuple([bad_type_docs,undefined_key_docs])
+            
+    
+def check_required(db,
+                collection='site',
+                keys=['lat','lon','elev','starttime','endtime'],
+                query={},
+                verbose=False,
+                error_limit=100):
+    """
+    This function applies a test to assure a list of attributes 
+    are defined and of the right type.   This function is needed 
+    because certain attributes are essential in two different contexts.
+    First, for waveform data there are some attributes that are 
+    required to construct the data object (e.g. sample interal or 
+    sample rate, start time, etc.).  Secondly, workflows generally 
+    require certain Metadata and what is required depends upon the 
+    workflow.  For example, any work with sources normally requires
+    information about both station and instrument properties as well 
+    as source.  The opposite is noise correlation work where only 
+    station information is essential.  
+
+    :param db:  mspass Database handle.   Note this must be 
+      a Database class defined by "from mspasspy.db.database import Database".
+      The reason is that the mspass handle is an extension of MongoDB's 
+      handle that includes the Schema class used to run the tests in 
+      this function. This arg is required
+    :param collection:  MongoDB collection that is to be scanned 
+      for errors.  Note with normalized data this function should be 
+      run on the appropriate wf collection and all normalization 
+      collections the wf collection needs to link to. 
+    :param keys:  is a list of strings that are to be checked 
+      against the contents of the collection.  Note one of the first 
+      things the function does is test for the validity of the keys.  
+      If they are not defined in the schema the function will throw 
+      a MsPASSError exception. 
+    :param query:  optional dict passed as a query to limit the 
+      documents scanned by the function.   Default will process the 
+      entire collection requested.
+    :param verbose:  when True errors will be printed.   The default is
+      False and the function will do it's work silently.   Verbose is 
+      most useful in an interactive python session where the function 
+      is called directly.  Most users will run this function 
+      as part of tests driven by the dbverify program. 
+    :param error_limit: Is a sanity check the number of errors logged
+      The number of any type are limited to this number (default 1000).
+      The idea is errors should be rare and if this number is exceeded 
+      you have a big problem you need to fix before scanning again.  
+      The number should be large enough to catch all condition but 
+      not so huge it become cumbersome.  With no limit or a memory 
+      fault is even possible on a huge dataset.
+    :return:  tuple with two components. Both components contain a 
+      python dict container keyed by ObjectId of problem documents. 
+      The values in the component 0 dict are themselves python dict
+      containers that are like MongoDB subdocuments).  The key-value
+      pairs in that dict are required data with a type mismatch with the schema.
+      The values in component 1 are python lists of keys that had 
+      no assigned value but were defined as required.   
+    """
+    if len(keys)==0:
+        raise MsPASSError('check_required:  list of required keys is empty '
+                          + '- nothing to test','Fatal')
+    # The following two can throw MsPASS errors but we let them 
+    # do so. Callers should have a handler for MsPASSError
+    dbschema=db.database_schema
+    # This holds the schema for the collection to be scanned
+    # dbschema is mostly an index to one of these
+    col_schema=dbschema[collection]
+    dbcol=db[collection]
+    # We first make sure the user didn't make a mistake in giving an 
+    # invalid key for the required list
+    for k in keys:
+        if not col_schema.is_defined(k):
+            raise MsPASSError('check_required:  schema has no definition for key='
+                              + k,'Fatal')
+
+    n=dbcol.count_documents(query)
+    if n == 0:
+        raise MsPASSError('check_required:  query='
+                          +str(query)+' yields zero matching documents',
+                          'Fatal')
+    undef=dict()
+    wrong_types=dict()
+    cursor=dbcol.find(query)        
+    for doc in cursor:
+        id=doc['_id']
+        undef_this=list()
+        wrong_this=dict()
+        for k in keys:
+            if not k in doc:
+                undef_this.append(k)
+            else:
+                val=doc[k]
+                if type(val)!=col_schema.type(k):
+                    wrong_this[k]=val
+        if len(undef_this)>0:
+            undef[id]=undef_this
+        if len(wrong_this)>0:
+            wrong_types[id]=wrong_this
+        if len(wrong_types)>=error_limit or len(undef)>=error_limit:
+            break
+    return tuple([wrong_types,undef])
+                


### PR DESCRIPTION
These changes should be completely orthogonal to anything else in the repository.   There are some thing that will need further action though:
1.  I put the command line tool (python program with a main) dbverify in mspasspy.db.scripts as you suggested.   I have no idea how to change setup to have it installed in some kind of bin directory.   I leave that to one of my fellow collaborators. 
2. I wrote the man page in old school classic unix nroff with the -man dialect - the standard language for unix man pages for close to 40 years.  If you want it in a different structure, there are likely converters because man pages are everywhere.  I created a docs/source/man/man1 directory and put the file there.  