### PR TITLE
Fix incorrectly named keyword

### DIFF
--- a/cxx/include/mspass/seismic/keywords.h
+++ b/cxx/include/mspass/seismic/keywords.h
@@ -55,7 +55,7 @@ const std::string SEISMICMD_slat("source_lat");
 /*! Longitude (in degrees) of the hypocenter of seismic source*/
 const std::string SEISMICMD_slon("source_lon");
 /*! Depth (in km) of the hypocenter of seismic source*/
-const std::string SEISMICMD_selev("source_elev");
+const std::string SEISMICMD_sdepth("source_depth");
 /*! Origin time of the hypocenter of a seismic source.*/
 const std::string SEISMICMD_stime("source_time");
 /*! External data file name.*/

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -153,7 +153,7 @@ PYBIND11_MODULE(seismic, m) {
   Keywords["channel_vang"] = SEISMICMD_vang;
   Keywords["source_lat"] = SEISMICMD_slat;
   Keywords["source_lon"] = SEISMICMD_slon;
-  Keywords["source_elev"] = SEISMICMD_selev;
+  Keywords["source_depth"] = SEISMICMD_sdepth;
   Keywords["source_time"] = SEISMICMD_stime;
   Keywords["dfile"] = SEISMICMD_dfile;
   Keywords["dir"] = SEISMICMD_dir;


### PR DESCRIPTION
This is a trivial fixed in the c++ code for mistake in the name for souce depth.  Was incorrectly tagged as SEISMICMD_selev and set as source_selev.  Changed selev to sdepth.  

Only complication is watch the history.  I incorrectly forgot to switch the branch name and originally committed these to master.  To allow me to push it to github I did
```
git checkout fix_keyword_bug
git merge master
```
then pushed it here.   Not sure if that will mess up the history chain or not.