### PR TITLE
Revise CMake config

### DIFF
--- a/cxx/src/lib/CMakeLists.txt
+++ b/cxx/src/lib/CMakeLists.txt
@@ -2,8 +2,7 @@ add_subdirectory(utility)
 add_subdirectory(seismic)
 add_subdirectory(algorithms)
 
-file(WRITE ${CMAKE_BINARY_DIR}/src/dummy.cc "")
-add_library(mspass ${CMAKE_BINARY_DIR}/src/dummy.cc)
-target_link_libraries(mspass PUBLIC seismic utility deconvolution algorithms)
+add_library(mspass $<TARGET_OBJECTS:seismic> $<TARGET_OBJECTS:utility> $<TARGET_OBJECTS:alg_basics> $<TARGET_OBJECTS:amplitudes> $<TARGET_OBJECTS:deconvolution>)
+target_link_libraries(mspass PRIVATE ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${YAML_CPP_LIBRARIES} ${PYTHON_LIBRARIES} ${GSL_LIBRARIES})
 
 install (TARGETS mspass DESTINATION lib)

--- a/cxx/src/lib/algorithms/CMakeLists.txt
+++ b/cxx/src/lib/algorithms/CMakeLists.txt
@@ -17,15 +17,10 @@ include_directories(
   ${PROJECT_BINARY_DIR}/include
   ${PROJECT_SOURCE_DIR}/include)
 
-add_library(alg_basics STATIC ${sources_alg_basics})
-add_library(amplitudes STATIC ${sources_amplitudes})
-target_link_libraries(alg_basics PRIVATE utility seismic deconvolution ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${GSL_LIBRARIES})
-target_link_libraries(amplitudes PRIVATE utility seismic ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+add_library(alg_basics OBJECT ${sources_alg_basics})
+add_library(amplitudes OBJECT ${sources_amplitudes})
 
 add_subdirectory(deconvolution)
 
-file(WRITE ${CMAKE_BINARY_DIR}/src/dummy.cc "")
-add_library(algorithms ${CMAKE_BINARY_DIR}/src/dummy.cc)
-target_link_libraries(algorithms PUBLIC alg_basics amplitudes deconvolution)
-
-install (TARGETS algorithms DESTINATION lib)
+#add_library(algorithms OBJECT $<TARGET_OBJECTS:alg_basics> $<TARGET_OBJECTS:amplitudes> $<TARGET_OBJECTS:deconvolution>)
+#target_link_libraries(algorithms PRIVATE seismic utility ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${GSL_LIBRARIES})

--- a/cxx/src/lib/algorithms/deconvolution/CMakeLists.txt
+++ b/cxx/src/lib/algorithms/deconvolution/CMakeLists.txt
@@ -7,5 +7,5 @@ include_directories(
   ${PROJECT_BINARY_DIR}/include
   ${PROJECT_SOURCE_DIR}/include)
 
-add_library(deconvolution STATIC ${sources_deconvolution})
-target_link_libraries(deconvolution PRIVATE seismic utility alg_basics ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${GSL_LIBRARIES} )
+add_library(deconvolution OBJECT ${sources_deconvolution})
+#target_link_libraries(deconvolution PRIVATE seismic utility alg_basics ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${GSL_LIBRARIES} )

--- a/cxx/src/lib/seismic/CMakeLists.txt
+++ b/cxx/src/lib/seismic/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
   ${PROJECT_BINARY_DIR}/include
   ${PROJECT_SOURCE_DIR}/include)
 
-add_library(seismic STATIC ${sources_seismic})
-target_link_libraries(seismic PRIVATE utility ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+add_library(seismic OBJECT ${sources_seismic})
+#target_link_libraries(seismic PRIVATE utility ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 
-install (TARGETS seismic DESTINATION lib)
+#install (TARGETS seismic DESTINATION lib)

--- a/cxx/src/lib/utility/CMakeLists.txt
+++ b/cxx/src/lib/utility/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/include
   ${PROJECT_BINARY_DIR}/include)
 
-add_library(utility STATIC ${sources_utility})
-target_link_libraries(utility PRIVATE ${BLAS_LIBRARIES} ${YAML_CPP_LIBRARIES} ${PYTHON_LIBRARIES})
+add_library(utility OBJECT ${sources_utility})
+#target_link_libraries(utility PRIVATE ${BLAS_LIBRARIES} ${YAML_CPP_LIBRARIES} ${PYTHON_LIBRARIES})
 
-install (TARGETS utility DESTINATION lib)
+#install (TARGETS utility DESTINATION lib)


### PR DESCRIPTION
The cxx code should be built into a single library to avoid confusion. We switched the static libraries to object libraries in cmake to maintain the original build structure. 