### PR TITLE
Fix empty string issue in serializing Metadata

### DIFF
--- a/cxx/include/mspass/utility/Metadata.h
+++ b/cxx/include/mspass/utility/Metadata.h
@@ -432,6 +432,26 @@ other attributes.
   */
   void change_key(const std::string oldkey, const std::string newkey);
   friend std::ostringstream& operator<<(std::ostringstream&, mspass::utility::Metadata&);
+  /*! Serialize Metadata to a python bytes object.
+
+  This function is needed to support pickle in the python interface.
+  It cast the C++ object to a Python dict and calls pickle against that
+  dict directly to generate a Python bytes object. This may not be the 
+  most elegant approach, but it should be bombproof.
+
+  \param md is the Metadata object to be serialized
+  \return pickle serialized data object.
+  */
+  friend pybind11::object serialize_metadata(const Metadata &md);
+  /*! Unpack serialized Metadata.
+  *
+  This function is the inverse of the serialize function.   It recreates a
+  Metadata object serialized previously with the serialize function.  
+
+  \param sd is the serialized data to be unpacked
+  \return Metadata derived from sd
+  */
+  friend Metadata restore_serialized_metadata(const pybind11::object &sd);
 protected:
   std::map<std::string,boost::any> md;
   /* The keys of any entry changed will be contained here.   */
@@ -528,45 +548,8 @@ from a data object).
 */
 int copy_selected_metadata(const Metadata& mdin, Metadata& mdout,
         const MetadataList& mdlist);
-/*! Serialize Metadata to a string.
 
-This function is needed to support pickle in the python interface.
-It is called in the pickle definitions in the wrapper for objects using
-Metadata to provide a way to serialize the contents of the Metadata
-object to a string.   The data that string contains is expected to
-restored with the inverse of this function called restore.
-
-Serialized output is readable with each entry on one line with
-this format:
-key type value
-where type is restricted to double, long, bool, and the long C++ name for
-an std::string.  Currently this:
-std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >
-
-Note any entry not of the four supported types will generate an error message
-posted to stderr.   That is an ugly approach, but an intentional design
-decision as this function should normally be called only pickling
-methods for data objects.   Could see no solution to save errors in
-that environment without throwing an exception and aborting the processing.
-
-\param md is the Metadata object to be serialized
-\return std::string of serialized data.
-*/
-std::string serialize_metadata(const Metadata& md);
-/*! Unpack serialized Metadata.
- *
-This function is the inverse of the serialize function.   It recreates a
-Metadata object serialized previous with the serialize function.  Note it
-only supports basic types currently supported by mspass:  long ints, double,
-boolean, and string.  Since the output is assumed to be form serialize we
-do not test for validity of the type assuming serialize didn't handle
-anything else.
-
-\param sd is the serialized data to be unpacked
-\return Metadata derived from sd
-*/
-Metadata restore_serialized_metadata(const std::string);
-
+Metadata restore_serialized_metadata(const pybind11::object &sd);
 } // end utility namespace
 }  //End of namespace MsPASS
 #endif

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -363,7 +363,7 @@ PYBIND11_MODULE(seismic, m) {
        "Load ProcessingHistory from another data object that contains relevant history")
     .def(py::pickle(
       [](const Seismogram &self) {
-        string sbuf;
+        pybind11::object sbuf;
         sbuf=serialize_metadata(self);
         stringstream ssbts;
         ssbts << std::setprecision(17);
@@ -395,9 +395,8 @@ PYBIND11_MODULE(seismic, m) {
         }
       },
       [](py::tuple t) {
-        string sbuf=t[0].cast<std::string>();
-        Metadata md;
-        md=Metadata(restore_serialized_metadata(sbuf));
+        pybind11::object sbuf=t[0];
+        Metadata md=restore_serialized_metadata(sbuf);
         stringstream ssbts(t[1].cast<std::string>());
         boost::archive::text_iarchive arbts(ssbts);
         BasicTimeSeries bts;
@@ -484,7 +483,7 @@ PYBIND11_MODULE(seismic, m) {
         */
       .def(py::pickle(
         [](const TimeSeries &self) {
-          string sbuf;
+          pybind11::object sbuf;
           sbuf=serialize_metadata(self);
           stringstream ssbts;
           ssbts << std::setprecision(17);
@@ -499,9 +498,8 @@ PYBIND11_MODULE(seismic, m) {
           return py::make_tuple(sbuf,ssbts.str(),sscorets.str(),darr);
         },
         [](py::tuple t) {
-         string sbuf=t[0].cast<std::string>();
-         Metadata md;
-         md=Metadata(restore_serialized_metadata(sbuf));
+         pybind11::object sbuf=t[0];
+         Metadata md=restore_serialized_metadata(sbuf);
          stringstream ssbts(t[1].cast<std::string>());
          boost::archive::text_iarchive arbts(ssbts);
          BasicTimeSeries bts;

--- a/cxx/python/seismic/seismic_py.cc
+++ b/cxx/python/seismic/seismic_py.cc
@@ -364,7 +364,7 @@ PYBIND11_MODULE(seismic, m) {
     .def(py::pickle(
       [](const Seismogram &self) {
         pybind11::object sbuf;
-        sbuf=serialize_metadata(self);
+        sbuf=serialize_metadata_py(self);
         stringstream ssbts;
         ssbts << std::setprecision(17);
         boost::archive::text_oarchive arbts(ssbts);
@@ -396,7 +396,7 @@ PYBIND11_MODULE(seismic, m) {
       },
       [](py::tuple t) {
         pybind11::object sbuf=t[0];
-        Metadata md=restore_serialized_metadata(sbuf);
+        Metadata md=restore_serialized_metadata_py(sbuf);
         stringstream ssbts(t[1].cast<std::string>());
         boost::archive::text_iarchive arbts(ssbts);
         BasicTimeSeries bts;
@@ -484,7 +484,7 @@ PYBIND11_MODULE(seismic, m) {
       .def(py::pickle(
         [](const TimeSeries &self) {
           pybind11::object sbuf;
-          sbuf=serialize_metadata(self);
+          sbuf=serialize_metadata_py(self);
           stringstream ssbts;
           ssbts << std::setprecision(17);
           boost::archive::text_oarchive arbts(ssbts);
@@ -499,7 +499,7 @@ PYBIND11_MODULE(seismic, m) {
         },
         [](py::tuple t) {
          pybind11::object sbuf=t[0];
-         Metadata md=restore_serialized_metadata(sbuf);
+         Metadata md=restore_serialized_metadata_py(sbuf);
          stringstream ssbts(t[1].cast<std::string>());
          boost::archive::text_iarchive arbts(ssbts);
          BasicTimeSeries bts;

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -254,6 +254,7 @@ PYBIND11_MODULE(utility, m) {
         else
           md->put_object(std::string(py::str(i.first)), py::reinterpret_borrow<py::object>(i.second));
       }
+      md->clear_modified();
       return md;
     }))
     .def("get_double",&Metadata::get_double,"Retrieve a real number by a specified key")
@@ -386,13 +387,13 @@ PYBIND11_MODULE(utility, m) {
     /* these are need to allow the class to be pickled*/
     .def(py::pickle(
       [](const Metadata &self) {
-        string sbuf;
+        pybind11::object sbuf;
         sbuf=serialize_metadata(self);
         return py::make_tuple(sbuf);
       },
       [](py::tuple t) {
-       string sbuf=t[0].cast<std::string>();
-       return Metadata(restore_serialized_metadata(sbuf));
+       pybind11::object sbuf=t[0];
+       return restore_serialized_metadata(sbuf);
      }
      ))
   ;

--- a/cxx/python/utility/utility_py.cc
+++ b/cxx/python/utility/utility_py.cc
@@ -180,8 +180,8 @@ static PyObject *MsPASSError_get_severity(PyObject *selfPtr, void *closure)
 }
 
 static PyGetSetDef MsPASSError_getsetters[] = {
-  {"message", (getter)MsPASSError_get_message, NULL, NULL},
-  {"severity", (getter)MsPASSError_get_severity, NULL, NULL},
+  {const_cast<char*>("message"), (getter)MsPASSError_get_message, NULL, NULL},
+  {const_cast<char*>("severity"), (getter)MsPASSError_get_severity, NULL, NULL},
   {NULL}
 };
 
@@ -388,12 +388,12 @@ PYBIND11_MODULE(utility, m) {
     .def(py::pickle(
       [](const Metadata &self) {
         pybind11::object sbuf;
-        sbuf=serialize_metadata(self);
+        sbuf=serialize_metadata_py(self);
         return py::make_tuple(sbuf);
       },
       [](py::tuple t) {
        pybind11::object sbuf=t[0];
-       return restore_serialized_metadata(sbuf);
+       return restore_serialized_metadata_py(sbuf);
      }
      ))
   ;

--- a/cxx/src/lib/utility/Metadata.cc
+++ b/cxx/src/lib/utility/Metadata.cc
@@ -280,8 +280,22 @@ ostringstream& operator<<(ostringstream& os, Metadata& m)
     return os;
   }catch(...){throw;};
 }
+/* This function is very much like operator<< except it is more
+ * restricted on allowed types and it add a type name to the output */
+std::string serialize_metadata(const Metadata& md)
+{
+  try {
+    ostringstream ss;
+    /* We do this to make sure we don't truncate precision */
+    ss << setprecision(17);
+    ss << const_cast<Metadata &>(md);
+    return std::string(ss.str());
+  }
+  catch (...){throw;};
+}
+
 /* This function is implemented with pybind11 so it should only be called under python. */
-pybind11::object serialize_metadata(const Metadata &md)
+pybind11::object serialize_metadata_py(const Metadata &md)
 {
   pybind11::gil_scoped_acquire acquire;
   try{
@@ -294,8 +308,78 @@ pybind11::object serialize_metadata(const Metadata &md)
     return md_dump;
   }catch(...){pybind11::gil_scoped_release release;throw;};
 }
+/* This has a lot more complexity but assumes a series of lines
+ * defined by ostringstream operator:  key, type, value
+ * */
+Metadata restore_serialized_metadata(const std::string s)
+{
+  try {
+    stringstream ss(s);
+    Metadata md;
+    string key, typ;
+    double dval;
+    long int ival;
+    bool bval;
+    string sval;
+    do
+    {
+      ss >> key;
+      key = misc::base64_decode(key);
+      ss >> typ;
+      if (ss.eof())
+        break; // normal exit of this loop is here
+      if (typ == "double")
+      {
+        ss >> dval;
+        md.put(key, dval);
+      }
+      else if ((typ == "long") || (typ == "int"))
+      {
+        ss >> ival;
+        md.put(key, ival);
+      }
+      else if (typ == "bool")
+      {
+        ss >> bval;
+        md.put(key, bval);
+      }
+      /* this assumes output has been made pretty so this simple test works*/
+      else if (typ == "string")
+      {
+        ss >> sval;
+        sval = misc::base64_decode(sval);
+        md.put(key, sval);
+      }
+      else if (typ == "pybind11::object")
+      {
+        ss >> sval;
+        pybind11::str pyStr = pybind11::str(sval.c_str(), sval.size());
+        pybind11::gil_scoped_acquire acquire;
+        pybind11::module pickle = pybind11::module::import("pickle");
+        pybind11::module codecs = pybind11::module::import("codecs");
+        pybind11::object loads = pickle.attr("loads");
+        pybind11::object decode = codecs.attr("decode");
+        /* The following in Python will be pickle.loads(codecs.decode(pyStr.encode(), "base64"))
+          * The complexity is to ensure the bytes string to be valid UTF-8 */
+        pybind11::object poval = loads(decode(pyStr.attr("encode")(), "base64"));
+        md.put_object(key, poval);
+        pybind11::gil_scoped_release release;
+      }
+      else
+      {
+        cerr << "restore_serialized (WARNING):  unrecognized type for key=" << key
+             << " of " << typ << endl
+             << "Trying to save as string" << endl;
+        ss >> sval;
+        md.put(key, sval);
+      }
+    } while (!ss.eof());
+    return md;
+  }catch(...){throw;};
+}
+
 /* This is the reverse of serialize_metadata also using pybind11. */
-Metadata restore_serialized_metadata(const pybind11::object &s)
+Metadata restore_serialized_metadata_py(const pybind11::object &s)
 {
   pybind11::gil_scoped_acquire acquire;
   try{

--- a/cxx/test/md/test_md.cc
+++ b/cxx/test/md/test_md.cc
@@ -56,16 +56,16 @@ int main(int argc, char **argv)
 		ss << mdplain;
 		cout << "Succeeded - stringstream contents:"<<endl;
 		cout << ss.str()<<endl;
-		cout<< "Trying same with serialize_metadata function"<<endl;
-		string sbuf=serialize_metadata(mdplain);
-		cout<<"Serialized completed: content "<<endl
-			<<"(should be same as stringstream output above)"<<endl;
-		cout <<sbuf;
-		cout << "Trying to run inverse function restore_serialized_metadata "
-			<<"on sterialization output"<<endl;
-		Metadata mrestored=restore_serialized_metadata(sbuf);
-		cout<<"Result - should again be the same"<<endl;
-		print_metadata(mrestored);
+		// cout<< "Trying same with serialize_metadata function"<<endl;
+		// string sbuf=serialize_metadata(mdplain);
+		// cout<<"Serialized completed: content "<<endl
+		// 	<<"(should be same as stringstream output above)"<<endl;
+		// cout <<sbuf;
+		// cout << "Trying to run inverse function restore_serialized_metadata "
+		// 	<<"on sterialization output"<<endl;
+		// Metadata mrestored=restore_serialized_metadata(sbuf);
+		// cout<<"Result - should again be the same"<<endl;
+		// print_metadata(mrestored);
                 cout << "Same thing using operator >> to cout"<<endl;
 		print_metadata(mdplain);
 		cout << "Testing is_defined and clear methods"<<endl;

--- a/cxx/test/md/test_md.cc
+++ b/cxx/test/md/test_md.cc
@@ -56,16 +56,16 @@ int main(int argc, char **argv)
 		ss << mdplain;
 		cout << "Succeeded - stringstream contents:"<<endl;
 		cout << ss.str()<<endl;
-		// cout<< "Trying same with serialize_metadata function"<<endl;
-		// string sbuf=serialize_metadata(mdplain);
-		// cout<<"Serialized completed: content "<<endl
-		// 	<<"(should be same as stringstream output above)"<<endl;
-		// cout <<sbuf;
-		// cout << "Trying to run inverse function restore_serialized_metadata "
-		// 	<<"on sterialization output"<<endl;
-		// Metadata mrestored=restore_serialized_metadata(sbuf);
-		// cout<<"Result - should again be the same"<<endl;
-		// print_metadata(mrestored);
+		cout<< "Trying same with serialize_metadata function"<<endl;
+		string sbuf=serialize_metadata(mdplain);
+		cout<<"Serialized completed: content "<<endl
+			<<"(should be same as stringstream output above)"<<endl;
+		cout <<sbuf;
+		cout << "Trying to run inverse function restore_serialized_metadata "
+			<<"on sterialization output"<<endl;
+		Metadata mrestored=restore_serialized_metadata(sbuf);
+		cout<<"Result - should again be the same"<<endl;
+		print_metadata(mrestored);
                 cout << "Same thing using operator >> to cout"<<endl;
 		print_metadata(mdplain);
 		cout << "Testing is_defined and clear methods"<<endl;

--- a/python/tests/test_ccore.py
+++ b/python/tests/test_ccore.py
@@ -271,6 +271,9 @@ def test_Metadata():
             assert (md[i] == md_copy[i]).all()
         else:
             assert md[i] == md_copy[i]
+    md_copy2 = Metadata(dict(md))
+    assert not md_copy2.modified()
+    assert md.modified() == md_copy.modified()
 
     md = Metadata({
         "<class 'numpy.ndarray'>": np.array([3, 4]),
@@ -306,12 +309,22 @@ def test_Metadata():
     md += md_copy
     assert md.__repr__() == "Metadata({'1': 1, '2': 2, '3': 30})"
 
-    # Error found with real data
-    #dic = {'_format': 'MSEED', 'arrival.time': 1356901212.242550, 'calib': 1.000000, 'chan': 'BHZ', 'delta': 0.025000, 'deltim': -1.000000, 'endtime': 1356904168.544538, 'iphase': 'P', 'loc': '', 'mseed': {'dataquality': 'D', 'number_of_records': 36, 'encoding': 'STEIM2', 'byteorder': '>', 'record_length': 4096, 'filesize': 726344704}, 'net': 'CI', 'npts': 144000, 'phase': 'P', 'sampling_rate': 40.000000, 'site.elev': 0.258000, 'site.lat': 35.126900, 'site.lon': -118.830090, 'site_id': '5fb6a67b37f8eef2f0658e9a', 'sta': 'ARV', 'starttime': 1356900568.569538}
-    #md = Metadata(dic)
-    #md_copy = pickle.loads(pickle.dumps(md))
-    # for i in md:
-    #    assert md[i] == md_copy[i]
+    # Test with real data
+    dic =  {'_format': 'MSEED', 'arrival.time': 1356901212.242550, 'calib': 1.000000, 
+        'chan': 'BHZ', 'delta': 0.025000, 'deltim': -1.000000, 'endtime': 1356904168.544538, 
+        'iphase': 'P', 'loc': '', 
+        'mseed': {'dataquality': 'D', 'number_of_records': 36, 'encoding': 'STEIM2', 
+            'byteorder': '>', 'record_length': 4096, 'filesize': 726344704}, 
+        'net': 'CI', 'npts': 144000, 'phase': 'P', 'sampling_rate': 40.000000, 
+        'site.elev': 0.258000, 'site.lat': 35.126900, 'site.lon': -118.830090, 
+        'site_id': '5fb6a67b37f8eef2f0658e9a', 'sta': 'ARV', 'starttime': 1356900568.569538
+        }
+    md = Metadata(dic)
+    md['mod'] = 'mod'
+    md_copy = pickle.loads(pickle.dumps(md))
+    for i in md:
+        assert md[i] == md_copy[i]
+    assert md.modified() == md_copy.modified()
 
 
 @pytest.fixture(params=[Seismogram, SeismogramEnsemble,


### PR DESCRIPTION
This is an attempt to fix #173, the serialization problem in `Metadata`.  Because we previously rely on parsing its contents into strings, an empty string can confuse the parser when deserializing. The fix is simple but not necessarily efficient: convert the `Metadata` to `dict` and then pickle it. The previously ignored `changed_or_set` member variable is also properly serialized in this version. 
