### PR TITLE
Add missing entries for python api section

### DIFF
--- a/docs/source/python_api/mspasspy.algorithms.rst
+++ b/docs/source/python_api/mspasspy.algorithms.rst
@@ -57,6 +57,14 @@ edit
     :undoc-members:
     :show-inheritance:
 
+ml
+--
+
+.. automodule:: mspasspy.algorithms.ml.arrival
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 resample
 --------
 
@@ -64,7 +72,6 @@ resample
     :members:
     :undoc-members:
     :show-inheritance:
-
 
 signals
 -------

--- a/docs/source/python_api/mspasspy.db.rst
+++ b/docs/source/python_api/mspasspy.db.rst
@@ -17,6 +17,22 @@ database
     :undoc-members:
     :show-inheritance:
 
+ensembles
+---------
+
+.. automodule:: mspasspy.db.database
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+matcher
+-------
+
+.. automodule:: mspasspy.db.database
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 normalize
 ---------
 
@@ -27,6 +43,14 @@ normalize
 
 schema
 ------
+
+.. automodule:: mspasspy.db.schema
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+spectrumdb
+----------
 
 .. automodule:: mspasspy.db.schema
     :members:

--- a/docs/source/python_api/mspasspy.util.rst
+++ b/docs/source/python_api/mspasspy.util.rst
@@ -9,6 +9,14 @@ converter
     :undoc-members:
     :show-inheritance:
 
+db_utils
+----------
+
+.. automodule:: mspasspy.util.decorators
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 decorators
 ----------
 


### PR DESCRIPTION
This change only affects the documentation and no the code base.   I partially address Issue #679.   I also discovered several other new modules that hadn't been added to the index.  That is now resolved as far as I know.  

Unless this creates some unanticipated problem I urge it be merged immediately and mspass.org be updated so it has these missing modules on the web site. 