### PR TITLE
Refactor MongoDBWorker to take MSPASS Client for DB connection

### DIFF
--- a/python/mspasspy/client.py
+++ b/python/mspasspy/client.py
@@ -239,16 +239,7 @@ class Client:
 
         # Auto-register MongoDB worker plugin for dask to avoid DB serialization leaks
         if self._scheduler == "dask":
-            dbname = self._default_database_name
-            url = getattr(self._db_client, "_mspass_db_host", None)
-            if url is None:
-                url = "mongodb://localhost:27017/"
-            elif isinstance(url, str) and not url.startswith("mongodb://"):
-                url = f"mongodb://{url}"
-
-            mongo_plugin = MongoDBWorker(
-                dbname=dbname, url=url, dbclient_key="dbclient"
-            )
+            mongo_plugin = MongoDBWorker(self, dbclient_key="dbclient")
             self._dask_client.register_plugin(mongo_plugin, name="mongodb_worker")
 
     def get_database_client(self):

--- a/python/mspasspy/util/db_utils.py
+++ b/python/mspasspy/util/db_utils.py
@@ -64,14 +64,22 @@ class MongoDBWorker(WorkerPlugin):
     Creates a DBClient instance for each worker and stores it in worker.data.
     This ensures each worker has its own database connection to prevent
     connection leaks when Database objects are serialized to workers.
+
+    :param mspass_client: MSPASS :class:`~mspasspy.client.Client` (or any object
+        with ``get_database_client()`` returning a :class:`~mspasspy.db.client.DBClient`).
+        The worker uses that client's ``_mspass_db_host`` for per-worker connections.
+    :param dbclient_key: Key under ``worker.data`` for the created :class:`~mspasspy.db.client.DBClient`.
     """
 
-    def __init__(
-        self, dbname, url="mongodb://localhost:27017/", dbclient_key="dbclient"
-    ):
-        self.dbname = dbname
-        self.connection_url = url
+    def __init__(self, mspass_client, dbclient_key="dbclient"):
         self.dbclient_key = dbclient_key
+        db_client = mspass_client.get_database_client()
+        url = getattr(db_client, "_mspass_db_host", None)
+        if url is None:
+            url = "mongodb://localhost:27017/"
+        elif isinstance(url, str) and not url.startswith("mongodb://"):
+            url = "mongodb://{}".format(url)
+        self.connection_url = url
 
     def setup(self, worker):
         """Called when worker starts - create DBClient for this worker."""

--- a/python/tests/io/test_distributed.py
+++ b/python/tests/io/test_distributed.py
@@ -30,6 +30,17 @@ from mspasspy.db.normalize import ObjectIdMatcher
 from mspasspy.ccore.utility import ErrorSeverity
 from mspasspy.util.db_utils import MongoDBWorker
 
+
+class _MongoPluginMsPASSClientStub:
+    """Minimal object with get_database_client() for MongoDBWorker tests."""
+
+    def __init__(self, db_client):
+        self._db_client = db_client
+
+    def get_database_client(self):
+        return self._db_client
+
+
 # globals for this test module
 number_atomic_wf = 5  # with 3 partitions this intentionally gives uneven sizes
 number_ensemble_wf = 4  # intentionaly not same as number_atomic_wf
@@ -1057,7 +1068,9 @@ def test_read_distributed_ensemble(
         context = None
         # Create Dask distributed client with MongoDB worker plugin for ensemble tests
         dask_client = DaskClient(processes=False, n_workers=2, threads_per_worker=1)
-        plugin = MongoDBWorker(dbname=testdbname, url="mongodb://localhost:27017/")
+        plugin = MongoDBWorker(
+            _MongoPluginMsPASSClientStub(DBClient("mongodb://localhost:27017/"))
+        )
         dask_client.register_worker_plugin(plugin)
 
     # warning src_data_list values must match string set in generators
@@ -1239,7 +1252,9 @@ def test_write_distributed_ensemble(
         context = None
         # Create Dask distributed client with MongoDB worker plugin for ensemble tests
         dask_client = DaskClient(processes=False, n_workers=2, threads_per_worker=1)
-        plugin = MongoDBWorker(dbname=testdbname, url="mongodb://localhost:27017/")
+        plugin = MongoDBWorker(
+            _MongoPluginMsPASSClientStub(DBClient("mongodb://localhost:27017/"))
+        )
         dask_client.register_worker_plugin(plugin)
     if collection == "wf_TimeSeries":
         wfid_list = TimeSeriesEnsemble_generator


### PR DESCRIPTION
## What this PR does

We change how the Dask **MongoDB worker plugin** gets its MongoDB connection settings. Instead of passing a database name and URL from outside, the plugin now takes the **MSPASS `Client`** and reads the host from the same internal path as the rest of the stack: `get_database_client()` and `_mspass_db_host`.

## Why

Previously the plugin API took `dbname` and `url` from the caller. The plugin never used `dbname` for setup, and requiring an externally supplied URL duplicated logic in `Client` (normalize host, default `mongodb://`, etc.). We prefer **not** to pass the MongoDB URL in from callers; it should be **derived inside** from the MSPASS `Client` / `DBClient`, so connection settings stay **one source of truth** and stay consistent with the rest of the code.

## What changed

| Area | Change |
|------|--------|
| `MongoDBWorker` | New constructor: `MongoDBWorker(mspass_client, dbclient_key="dbclient")`. Builds the connection URL from `get_database_client()` and `_mspass_db_host`, with the same normalization as before when the host is missing or has no `mongodb://` prefix. |
| `Client` | Registers the plugin with `MongoDBWorker(self)` instead of assembling `dbname` / `url` locally. |
| Tests | Distributed ensemble tests use a small stub that only implements `get_database_client()`, so the plugin is still registered on the **test’s** Dask client (not a second cluster from a full `Client`). |

## Breaking change

Any code that called `MongoDBWorker(dbname=..., url=...)` must now pass something that implements `get_database_client()` returning a `DBClient` (typically `mspasspy.client.Client`).

## Files

- `python/mspasspy/util/db_utils.py`
- `python/mspasspy/client.py`
- `python/tests/io/test_distributed.py`