### PR TITLE
Make MongoDBWorker pickle-safe for Dask register_plugin

### DIFF
--- a/python/mspasspy/util/db_utils.py
+++ b/python/mspasspy/util/db_utils.py
@@ -82,7 +82,10 @@ class MongoDBWorker(WorkerPlugin):
         self.connection_url = url
 
     def __getstate__(self):
-        return {"dbclient_key": self.dbclient_key, "connection_url": self.connection_url}
+        return {
+            "dbclient_key": self.dbclient_key,
+            "connection_url": self.connection_url,
+        }
 
     def __setstate__(self, state):
         self.dbclient_key = state["dbclient_key"]

--- a/python/mspasspy/util/db_utils.py
+++ b/python/mspasspy/util/db_utils.py
@@ -81,6 +81,13 @@ class MongoDBWorker(WorkerPlugin):
             url = "mongodb://{}".format(url)
         self.connection_url = url
 
+    def __getstate__(self):
+        return {"dbclient_key": self.dbclient_key, "connection_url": self.connection_url}
+
+    def __setstate__(self, state):
+        self.dbclient_key = state["dbclient_key"]
+        self.connection_url = state["connection_url"]
+
     def setup(self, worker):
         """Called when worker starts - create DBClient for this worker."""
         if self.connection_url is None:


### PR DESCRIPTION
## What

`MongoDBWorker` now implements `__getstate__` / `__setstate__` so only `dbclient_key` and `connection_url` get pickled. The real `DBClient` is still created in `setup()` on each worker.

## Why

Registering the plugin with Dask can pickle the `WorkerPlugin`. The default path sometimes pulls in things that don’t pickle cleanly (I’ve hit asyncio-related errors). This keeps registration reliable without changing how workers get a DB handle.
