### PR TITLE
Fix bug reported as issue 713

### DIFF
--- a/python/mspasspy/workflow.py
+++ b/python/mspasspy/workflow.py
@@ -309,6 +309,8 @@ def sliding_window_pipeline(
                 print(
                     "This setting makes sense only if you are running on a cluster service being used by multiple applications"
                 )
+        else:
+            swsize = sliding_window_size
     else:
 
         message = "{}: Illegal value for arg2.  Must be an instance of dask.distributed.Client".format(


### PR DESCRIPTION
This is a two line fix that resolves the bug reported as issue #713.   

Not resolved is that the function sliding_window_pipeline needs a pytest suite.  It doesn't have one because of the complexity of simulating a cluster for formal tests.